### PR TITLE
XML files for OldGerman

### DIFF
--- a/src/main/java/org/mycore/xml/AbbyyToAltoConverter.java
+++ b/src/main/java/org/mycore/xml/AbbyyToAltoConverter.java
@@ -69,7 +69,7 @@ public class AbbyyToAltoConverter {
     /**
      * Converts the given abbyy document to an ALTO one.
      * 
-     * @param abbyyXML the abbyy document
+     * @param abbyyDocument the abbyy document
      * @return ALTO xml
      */
     public Alto convert(Document abbyyDocument) {
@@ -287,14 +287,14 @@ public class AbbyyToAltoConverter {
                 string.setCONTENT(word.getValue());
                 try {
                     string.setWC(word.getWC());
-                } catch (Exception exc) {
-                    LOGGER.warn("Error while getting word confidence (WC) of " + word.getValue());
-                    string.setWC(0f);
+                } catch (Exception ignore) {
+                    //LOGGER.warn("Error while getting word confidence (WC) of " + word.getValue());
+                    //string.setWC(0f);
                 }
                 try {
                     string.setCC(word.getCC());
-                } catch (Exception exc) {
-                    LOGGER.warn("Error while getting character confidence (CC) of " + word.getValue());
+                } catch (Exception ignore) {
+                    //LOGGER.warn("Error while getting character confidence (CC) of " + word.getValue());
                 }
                 string.getSTYLEREFS().add(style);
                 wordRect.applyOnString(string);
@@ -304,7 +304,7 @@ public class AbbyyToAltoConverter {
     }
 
     /**
-     * Gets the alto {@link #TextStyle} by the abbyy formatting.
+     * Gets the alto {@link TextStyle} by the abbyy formatting.
      * 
      * @param styles the alto styles
      * @param abbyyFormatting the abbyy formatting
@@ -312,7 +312,13 @@ public class AbbyyToAltoConverter {
      */
     private TextStyle getTextStyle(Styles styles, FormattingType abbyyFormatting) {
         String fontFamily = abbyyFormatting.getFf();
+        if( fontFamily == null) {
+            fontFamily = "Times";
+        }
         Float fontSize = abbyyFormatting.getFs();
+        if( fontSize == null) {
+            fontSize = 10.f;
+        }
         List<String> fontStyles = new ArrayList<>();
         if (abbyyFormatting.isBold()) {
             fontStyles.add("bold");
@@ -327,7 +333,7 @@ public class AbbyyToAltoConverter {
     }
 
     /**
-     * Gets the {@link #TextStyle} for the given font family and size. Each alto document
+     * Gets the {@link TextStyle} for the given font family and size. Each alto document
      * have a pre defined list of fonts. If no text style is found, this method creates
      * an appropriate one.
      * 
@@ -349,7 +355,9 @@ public class AbbyyToAltoConverter {
         if (textStyle == null) {
             textStyle = new TextStyle();
             textStyle.setFONTFAMILY(fontFamily);
-            textStyle.setFONTSIZE(fontSize);
+            if( fontSize != null) {
+                textStyle.setFONTSIZE(fontSize);
+            }
             if (!fontStyles.isEmpty()) {
                 textStyle.setFONTSTYLE(fontStyles);
             }

--- a/src/test/java/org/mycore/xml/AbbyyToAltoConverterTest.java
+++ b/src/test/java/org/mycore/xml/AbbyyToAltoConverterTest.java
@@ -31,4 +31,14 @@ public class AbbyyToAltoConverterTest {
         System.out.println(JAXBUtil.marshalAltoToString(alto));
     }
 
+    @Test
+    public void convertOldGerman()   throws Exception {
+        InputStream inputStream = AbbyyToAltoConverter.class.getResourceAsStream("/OldGerman.xml");
+        Document document = JAXBUtil.unmarshalAbbyyDocument(inputStream);
+        Alto alto = new AbbyyToAltoConverter().convert(document);
+        assertNotNull("alto object should not be null", alto);
+        assertEquals("there should be 1 TextStyle element", 1, alto.getStyles().getTextStyle().size());
+        assertEquals("there should be exactly one page", 1, alto.getLayout().getPage().size());
+    }
+
 }

--- a/src/test/resources/OldGerman.xml
+++ b/src/test/resources/OldGerman.xml
@@ -1,0 +1,1152 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<document xmlns="http://www.abbyy.com/FineReader_xml/FineReader10-schema-v1.xml" version="1.0" producer="" languages="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.abbyy.com/FineReader_xml/FineReader10-schema-v1.xml http://www.abbyy.com/FineReader_xml/FineReader10-schema-v1.xml">
+<page width="2115" height="2784" resolution="300" originalCoords="1">
+<block blockType="Picture" l="238" t="167" r="538" b="508"><region><rect l="239" t="167" r="250" b="168"/><rect l="239" t="168" r="537" b="169"/><rect l="239" t="169" r="538" b="177"/><rect l="238" t="177" r="538" b="180"/><rect l="238" t="180" r="537" b="507"/><rect l="247" t="507" r="537" b="508"/></region>
+</block>
+<block blockType="Text" l="281" t="478" r="499" b="514"><region><rect l="281" t="478" r="499" b="514"/></region>
+<text>
+<par lineSpacing="830">
+<line baseline="511" l="287" t="484" r="493" b="508"><formatting lang="OldGerman">
+<charParams l="287" t="484" r="305" b="506">F</charParams>
+<charParams l="307" t="490" r="322" b="506">e</charParams>
+<charParams l="330" t="491" r="338" b="506" suspicious="1">r</charParams>
+<charParams l="347" t="490" r="360" b="506" suspicious="1">n</charParams>
+<charParams l="369" t="492" r="377" b="506" suspicious="1">r</charParams>
+<charParams l="385" t="491" r="399" b="507" suspicious="1">u</charParams>
+<charParams l="407" t="485" r="417" b="507">f</charParams>
+<charParams l="418" t="485" r="430" b="508"> </charParams>
+<charParams l="431" t="486" r="448" b="508">4</charParams>
+<charParams l="454" t="486" r="470" b="508">3</charParams>
+<charParams l="476" t="486" r="493" b="507">8</charParams></formatting></line></par>
+</text>
+</block>
+<block blockType="Text" l="570" t="212" r="1764" b="479"><region><rect l="571" t="212" r="655" b="213"/><rect l="570" t="213" r="1059" b="214"/><rect l="570" t="214" r="1464" b="215"/><rect l="570" t="215" r="1764" b="476"/><rect l="651" t="476" r="1764" b="477"/><rect l="1056" t="477" r="1764" b="478"/><rect l="1460" t="478" r="1764" b="479"/></region>
+<text>
+<par align="Right" lineSpacing="1340">
+<line baseline="266" l="576" t="219" r="1756" b="273"><formatting lang="OldGerman">
+<charParams l="576" t="219" r="619" b="257">P</charParams>
+<charParams l="626" t="229" r="649" b="257">r</charParams>
+<charParams l="655" t="219" r="695" b="258">ä</charParams>
+<charParams l="703" t="230" r="738" b="258">z</charParams>
+<charParams l="749" t="220" r="757" b="258" suspicious="1">i</charParams>
+<charParams l="770" t="230" r="803" b="259" suspicious="1">s</charParams>
+<charParams l="815" t="220" r="823" b="258" suspicious="1">i</charParams>
+<charParams l="836" t="230" r="875" b="259" suspicious="1">o</charParams>
+<charParams l="888" t="231" r="924" b="259" suspicious="1">n</charParams>
+<charParams l="936" t="230" r="970" b="260">s</charParams>
+<charParams l="975" t="242" r="995" b="249">-</charParams>
+<charParams l="999" t="221" r="1043" b="259">Z</charParams>
+<charParams l="1046" t="232" r="1084" b="272">y</charParams>
+<charParams l="1091" t="222" r="1099" b="260" suspicious="1">l</charParams>
+<charParams l="1113" t="222" r="1121" b="260" suspicious="1">i</charParams>
+<charParams l="1136" t="233" r="1172" b="260" suspicious="1">n</charParams>
+<charParams l="1180" t="222" r="1217" b="262" suspicious="1">d</charParams>
+<charParams l="1232" t="233" r="1270" b="262" suspicious="1">e</charParams>
+<charParams l="1281" t="233" r="1304" b="261">r</charParams>
+<charParams l="1309" t="245" r="1329" b="252">-</charParams>
+<charParams l="1334" t="223" r="1375" b="263">S</charParams>
+<charParams l="1384" t="234" r="1421" b="263">c</charParams>
+<charParams l="1429" t="224" r="1465" b="264">h</charParams>
+<charParams l="1476" t="225" r="1483" b="263" suspicious="1">l</charParams>
+<charParams l="1496" t="235" r="1534" b="264" suspicious="1">e</charParams>
+<charParams l="1547" t="225" r="1555" b="264" suspicious="1">i</charParams>
+<charParams l="1565" t="225" r="1583" b="263" suspicious="1">f</charParams>
+<charParams l="1586" t="236" r="1641" b="264">w</charParams>
+<charParams l="1645" t="235" r="1683" b="265">e</charParams>
+<charParams l="1689" t="236" r="1712" b="264">r</charParams>
+<charParams l="1720" t="226" r="1756" b="265">k</charParams></formatting></line></par>
+<par align="Right" lineSpacing="1880">
+<line baseline="384" l="582" t="301" r="1756" b="386"><formatting lang="OldGerman">
+<charParams l="582" t="301" r="684" b="380" suspicious="1">M</charParams>
+<charParams l="740" t="302" r="840" b="380" suspicious="1">A</charParams>
+<charParams l="888" t="302" r="986" b="380" suspicious="1">X</charParams>
+<charParams l="987" t="302" r="1107" b="381"> </charParams>
+<charParams l="1108" t="303" r="1186" b="381" suspicious="1">F</charParams>
+<charParams l="1234" t="305" r="1318" b="383" suspicious="1">U</charParams>
+<charParams l="1376" t="303" r="1466" b="384" suspicious="1">C</charParams>
+<charParams l="1524" t="306" r="1610" b="384" suspicious="1">H</charParams>
+<charParams l="1668" t="306" r="1756" b="386" suspicious="1">S</charParams></formatting></line></par>
+<par align="Right" lineSpacing="1340">
+<line baseline="464" l="578" t="419" r="1758" b="473"><formatting lang="OldGerman">
+<charParams l="578" t="420" r="585" b="458">I</charParams>
+<charParams l="599" t="420" r="644" b="459">N</charParams>
+<charParams l="657" t="420" r="707" b="460">G</charParams>
+<charParams l="718" t="420" r="770" b="461">O</charParams>
+<charParams l="781" t="421" r="813" b="460">L</charParams>
+<charParams l="823" t="420" r="866" b="460">S</charParams>
+<charParams l="871" t="420" r="911" b="460">T</charParams>
+<charParams l="914" t="421" r="963" b="459">A</charParams>
+<charParams l="971" t="422" r="1016" b="460">D</charParams>
+<charParams l="1022" t="421" r="1063" b="461">T</charParams>
+<charParams l="1064" t="422" r="1093" b="461"> </charParams>
+<charParams l="1094" t="432" r="1121" b="461" suspicious="1">E</charParams>
+<charParams l="1121" t="434" r="1134" b="461" suspicious="1">I</charParams>
+<charParams l="1138" t="453" r="1145" b="461">.</charParams>
+<charParams l="1146" t="424" r="1170" b="462"> </charParams>
+<charParams l="1171" t="424" r="1218" b="462">D</charParams>
+<charParams l="1224" t="453" r="1231" b="462">.</charParams>
+<charParams l="1237" t="452" r="1246" b="472" suspicious="1">,</charParams>
+<charParams l="1247" t="437" r="1272" b="472"> </charParams>
+<charParams l="1273" t="437" r="1297" b="462">L</charParams>
+<charParams l="1300" t="443" r="1332" b="462">a</charParams>
+<charParams l="1335" t="438" r="1363" b="462">b</charParams>
+<charParams l="1367" t="443" r="1396" b="463">o</charParams>
+<charParams l="1402" t="445" r="1420" b="461">r</charParams>
+<charParams l="1422" t="444" r="1452" b="462">a</charParams>
+<charParams l="1454" t="438" r="1471" b="463">t</charParams>
+<charParams l="1474" t="444" r="1504" b="464">o</charParams>
+<charParams l="1507" t="446" r="1527" b="463">r</charParams>
+<charParams l="1530" t="439" r="1537" b="464">l</charParams>
+<charParams l="1542" t="446" r="1569" b="464">u</charParams>
+<charParams l="1575" t="445" r="1623" b="464">m</charParams>
+<charParams l="1627" t="446" r="1654" b="464">s</charParams>
+<charParams l="1654" t="439" r="1673" b="464" suspicious="1">t</charParams>
+<charParams l="1676" t="446" r="1695" b="464" suspicious="1">r</charParams>
+<charParams l="1695" t="457" r="1702" b="464" suspicious="1">.</charParams>
+<charParams l="1703" t="440" r="1711" b="464" suspicious="1"> </charParams>
+<charParams l="1712" t="440" r="1726" b="464">1</charParams>
+<charParams l="1731" t="439" r="1758" b="465">8</charParams></formatting></line></par>
+</text>
+</block>
+<block blockType="Text" l="276" t="547" r="1764" b="864"><region><rect l="277" t="547" r="655" b="548"/><rect l="277" t="548" r="1059" b="549"/><rect l="277" t="549" r="1464" b="550"/><rect l="277" t="550" r="1763" b="551"/><rect l="277" t="551" r="1764" b="581"/><rect l="276" t="581" r="1764" b="584"/><rect l="276" t="584" r="1763" b="861"/><rect l="651" t="861" r="1763" b="862"/><rect l="1056" t="862" r="1763" b="863"/><rect l="1460" t="863" r="1763" b="864"/></region>
+<text>
+<par align="Justified" leftIndent="700" startIndent="7000" lineSpacing="1080">
+<line baseline="581" l="571" t="554" r="1757" b="585"><formatting lang="OldGerman">
+<charParams l="572" t="554" r="589" b="576">Z</charParams>
+<charParams l="591" t="560" r="605" b="582" suspicious="1">y</charParams>
+<charParams l="609" t="554" r="613" b="575" suspicious="1">l</charParams>
+<charParams l="617" t="554" r="622" b="576">i</charParams>
+<charParams l="625" t="560" r="638" b="576">n</charParams>
+<charParams l="642" t="554" r="658" b="577">d</charParams>
+<charParams l="662" t="561" r="676" b="577">e</charParams>
+<charParams l="680" t="562" r="690" b="577">r</charParams>
+<charParams l="691" t="568" r="699" b="571">-</charParams>
+<charParams l="704" t="556" r="722" b="577">B</charParams>
+<charParams l="726" t="562" r="740" b="578">e</charParams>
+<charParams l="744" t="561" r="759" b="578">a</charParams>
+<charParams l="762" t="562" r="771" b="577">r</charParams>
+<charParams l="774" t="555" r="789" b="577">b</charParams>
+<charParams l="793" t="561" r="807" b="577">e</charParams>
+<charParams l="812" t="556" r="815" b="576">i</charParams>
+<charParams l="817" t="555" r="829" b="577">t</charParams>
+<charParams l="831" t="562" r="844" b="577">u</charParams>
+<charParams l="848" t="562" r="861" b="578">n</charParams>
+<charParams l="864" t="563" r="879" b="583">g</charParams>
+<charParams l="879" t="562" r="900" b="583"> </charParams>
+<charParams l="901" t="562" r="914" b="578">n</charParams>
+<charParams l="919" t="562" r="934" b="578">a</charParams>
+<charParams l="937" t="562" r="950" b="578">c</charParams>
+<charParams l="954" t="556" r="967" b="578">h</charParams>
+<charParams l="968" t="556" r="988" b="578"> </charParams>
+<charParams l="989" t="556" r="1004" b="578">d</charParams>
+<charParams l="1008" t="562" r="1022" b="579">e</charParams>
+<charParams l="1027" t="562" r="1040" b="578">n</charParams>
+<charParams l="1041" t="556" r="1062" b="579"> </charParams>
+<charParams l="1063" t="557" r="1073" b="579">f</charParams>
+<charParams l="1084" t="563" r="1100" b="579">o</charParams>
+<charParams l="1113" t="564" r="1122" b="579">r</charParams>
+<charParams l="1132" t="558" r="1142" b="579">t</charParams>
+<charParams l="1153" t="563" r="1166" b="579">s</charParams>
+<charParams l="1178" t="562" r="1193" b="579">c</charParams>
+<charParams l="1204" t="558" r="1218" b="579">h</charParams>
+<charParams l="1232" t="563" r="1242" b="579">r</charParams>
+<charParams l="1253" t="558" r="1257" b="579">i</charParams>
+<charParams l="1268" t="557" r="1280" b="579">t</charParams>
+<charParams l="1289" t="558" r="1300" b="579">t</charParams>
+<charParams l="1311" t="558" r="1315" b="579">l</charParams>
+<charParams l="1329" t="558" r="1333" b="579">i</charParams>
+<charParams l="1345" t="563" r="1359" b="580">c</charParams>
+<charParams l="1371" t="558" r="1385" b="579">h</charParams>
+<charParams l="1398" t="564" r="1411" b="579">s</charParams>
+<charParams l="1422" t="557" r="1433" b="579">t</charParams>
+<charParams l="1443" t="564" r="1459" b="580">e</charParams>
+<charParams l="1471" t="564" r="1484" b="580">n</charParams>
+<charParams l="1485" t="558" r="1505" b="580"> </charParams>
+<charParams l="1506" t="558" r="1526" b="580">A</charParams>
+<charParams l="1530" t="565" r="1539" b="580">r</charParams>
+<charParams l="1542" t="558" r="1557" b="580">b</charParams>
+<charParams l="1560" t="564" r="1575" b="581">e</charParams>
+<charParams l="1579" t="559" r="1583" b="580">i</charParams>
+<charParams l="1585" t="558" r="1596" b="580">t</charParams>
+<charParams l="1598" t="564" r="1611" b="580">s</charParams>
+<charParams l="1615" t="564" r="1635" b="580">m</charParams>
+<charParams l="1639" t="565" r="1653" b="581">e</charParams>
+<charParams l="1656" t="559" r="1666" b="581">t</charParams>
+<charParams l="1669" t="560" r="1682" b="581">h</charParams>
+<charParams l="1687" t="565" r="1702" b="581">o</charParams>
+<charParams l="1707" t="561" r="1721" b="581">d</charParams>
+<charParams l="1725" t="565" r="1740" b="581">e</charParams>
+<charParams l="1744" t="565" r="1757" b="581">n</charParams></formatting></line>
+<line baseline="627" l="572" t="600" r="1756" b="632"><formatting lang="OldGerman">
+<charParams l="572" t="600" r="590" b="622">P</charParams>
+<charParams l="593" t="600" r="596" b="622">l</charParams>
+<charParams l="605" t="606" r="621" b="622">a</charParams>
+<charParams l="628" t="606" r="641" b="622">n</charParams>
+<charParams l="649" t="606" r="662" b="623">s</charParams>
+<charParams l="670" t="606" r="684" b="623">c</charParams>
+<charParams l="693" t="602" r="706" b="622">h</charParams>
+<charParams l="715" t="602" r="719" b="622">l</charParams>
+<charParams l="727" t="607" r="742" b="623">e</charParams>
+<charParams l="750" t="601" r="754" b="623">i</charParams>
+<charParams l="762" t="601" r="772" b="623">f</charParams>
+<charParams l="778" t="607" r="793" b="623">e</charParams>
+<charParams l="801" t="607" r="815" b="624">n</charParams>
+<charParams l="816" t="607" r="844" b="624"> </charParams>
+<charParams l="845" t="608" r="858" b="624">v</charParams>
+<charParams l="866" t="608" r="882" b="624">o</charParams>
+<charParams l="890" t="608" r="904" b="624">n</charParams>
+<charParams l="905" t="601" r="933" b="624"> </charParams>
+<charParams l="934" t="601" r="952" b="624">Z</charParams>
+<charParams l="959" t="608" r="972" b="629">y</charParams>
+<charParams l="980" t="601" r="985" b="623">l</charParams>
+<charParams l="994" t="601" r="998" b="624">i</charParams>
+<charParams l="1007" t="607" r="1020" b="624">n</charParams>
+<charParams l="1029" t="602" r="1044" b="624">d</charParams>
+<charParams l="1053" t="608" r="1067" b="625">e</charParams>
+<charParams l="1076" t="609" r="1086" b="624">r</charParams>
+<charParams l="1093" t="608" r="1106" b="625">n</charParams>
+<charParams l="1114" t="620" r="1120" b="630">,</charParams>
+<charParams l="1121" t="603" r="1141" b="630"> </charParams>
+<charParams l="1142" t="603" r="1160" b="625">Z</charParams>
+<charParams l="1167" t="608" r="1181" b="630">y</charParams>
+<charParams l="1188" t="603" r="1193" b="624">l</charParams>
+<charParams l="1201" t="602" r="1205" b="624">i</charParams>
+<charParams l="1214" t="608" r="1228" b="624">n</charParams>
+<charParams l="1236" t="602" r="1252" b="624">d</charParams>
+<charParams l="1260" t="608" r="1275" b="625">e</charParams>
+<charParams l="1283" t="609" r="1292" b="624">r</charParams>
+<charParams l="1300" t="603" r="1315" b="625">d</charParams>
+<charParams l="1324" t="609" r="1338" b="625">e</charParams>
+<charParams l="1346" t="608" r="1360" b="625">c</charParams>
+<charParams l="1368" t="602" r="1382" b="624">k</charParams>
+<charParams l="1390" t="609" r="1405" b="625">e</charParams>
+<charParams l="1413" t="603" r="1417" b="624">l</charParams>
+<charParams l="1425" t="609" r="1439" b="625">n</charParams>
+<charParams l="1446" t="619" r="1452" b="630">,</charParams>
+<charParams l="1453" t="603" r="1475" b="631"> </charParams>
+<charParams l="1476" t="604" r="1494" b="626">Z</charParams>
+<charParams l="1502" t="610" r="1515" b="632">y</charParams>
+<charParams l="1523" t="604" r="1528" b="626">l</charParams>
+<charParams l="1536" t="604" r="1541" b="626">i</charParams>
+<charParams l="1550" t="610" r="1564" b="626">n</charParams>
+<charParams l="1572" t="606" r="1587" b="626">d</charParams>
+<charParams l="1595" t="610" r="1610" b="626">e</charParams>
+<charParams l="1618" t="611" r="1627" b="625">r</charParams>
+<charParams l="1635" t="604" r="1649" b="626">k</charParams>
+<charParams l="1657" t="605" r="1672" b="625">ö</charParams>
+<charParams l="1681" t="610" r="1696" b="632">p</charParams>
+<charParams l="1702" t="603" r="1713" b="626">f</charParams>
+<charParams l="1719" t="610" r="1734" b="626">e</charParams>
+<charParams l="1742" t="610" r="1756" b="626">n</charParams></formatting></line>
+<line baseline="672" l="570" t="645" r="1756" b="677"><formatting lang="OldGerman">
+<charParams l="570" t="646" r="590" b="667">A</charParams>
+<charParams l="594" t="652" r="607" b="668">u</charParams>
+<charParams l="611" t="652" r="623" b="668">s</charParams>
+<charParams l="627" t="645" r="642" b="668">b</charParams>
+<charParams l="646" t="647" r="659" b="668">u</charParams>
+<charParams l="662" t="651" r="676" b="668">c</charParams>
+<charParams l="680" t="648" r="692" b="669">h</charParams>
+<charParams l="697" t="653" r="710" b="669">s</charParams>
+<charParams l="713" t="653" r="728" b="669">e</charParams>
+<charParams l="732" t="653" r="745" b="669">n</charParams>
+<charParams l="746" t="653" r="760" b="669"> </charParams>
+<charParams l="761" t="653" r="775" b="669">v</charParams>
+<charParams l="778" t="653" r="793" b="669">o</charParams>
+<charParams l="797" t="652" r="810" b="668">n</charParams>
+<charParams l="811" t="647" r="826" b="669"> </charParams>
+<charParams l="827" t="647" r="844" b="669">Z</charParams>
+<charParams l="848" t="653" r="861" b="674">y</charParams>
+<charParams l="864" t="647" r="869" b="669">l</charParams>
+<charParams l="873" t="647" r="877" b="669">i</charParams>
+<charParams l="881" t="653" r="894" b="669">n</charParams>
+<charParams l="898" t="647" r="913" b="669">d</charParams>
+<charParams l="917" t="653" r="932" b="669">e</charParams>
+<charParams l="937" t="654" r="946" b="669">r</charParams>
+<charParams l="948" t="653" r="961" b="669">n</charParams>
+<charParams l="962" t="646" r="992" b="670"> </charParams>
+<charParams l="993" t="646" r="998" b="670" suspicious="1">I</charParams>
+<charParams l="999" t="646" r="1028" b="670"> </charParams>
+<charParams l="1029" t="647" r="1048" b="669">A</charParams>
+<charParams l="1052" t="653" r="1065" b="670">n</charParams>
+<charParams l="1068" t="647" r="1078" b="669">f</charParams>
+<charParams l="1081" t="654" r="1095" b="670">e</charParams>
+<charParams l="1099" t="655" r="1108" b="669">r</charParams>
+<charParams l="1109" t="648" r="1120" b="670">t</charParams>
+<charParams l="1123" t="648" r="1126" b="669">i</charParams>
+<charParams l="1130" t="654" r="1145" b="675">g</charParams>
+<charParams l="1149" t="654" r="1163" b="670">e</charParams>
+<charParams l="1167" t="654" r="1181" b="670">n</charParams>
+<charParams l="1182" t="654" r="1195" b="670"> </charParams>
+<charParams l="1196" t="654" r="1210" b="670">v</charParams>
+<charParams l="1213" t="654" r="1229" b="670">o</charParams>
+<charParams l="1233" t="654" r="1246" b="670">n</charParams>
+<charParams l="1247" t="648" r="1262" b="670"> </charParams>
+<charParams l="1263" t="648" r="1282" b="669">V</charParams>
+<charParams l="1285" t="654" r="1300" b="670">e</charParams>
+<charParams l="1304" t="654" r="1317" b="669">n</charParams>
+<charParams l="1320" t="648" r="1329" b="669">t</charParams>
+<charParams l="1333" t="648" r="1336" b="669">i</charParams>
+<charParams l="1341" t="648" r="1345" b="670">l</charParams>
+<charParams l="1349" t="654" r="1363" b="670">e</charParams>
+<charParams l="1367" t="654" r="1380" b="670">n</charParams>
+<charParams l="1381" t="647" r="1405" b="672"> </charParams>
+<charParams l="1406" t="647" r="1413" b="672" suspicious="1">/</charParams>
+<charParams l="1414" t="647" r="1442" b="672"> </charParams>
+<charParams l="1443" t="648" r="1461" b="670">E</charParams>
+<charParams l="1464" t="649" r="1469" b="671">i</charParams>
+<charParams l="1472" t="655" r="1486" b="670">n</charParams>
+<charParams l="1490" t="649" r="1506" b="671">b</charParams>
+<charParams l="1509" t="655" r="1524" b="671">a</charParams>
+<charParams l="1527" t="656" r="1540" b="671">u</charParams>
+<charParams l="1543" t="649" r="1553" b="671">f</charParams>
+<charParams l="1556" t="655" r="1570" b="671">e</charParams>
+<charParams l="1574" t="655" r="1584" b="671">r</charParams>
+<charParams l="1584" t="649" r="1595" b="671">t</charParams>
+<charParams l="1598" t="649" r="1602" b="670">i</charParams>
+<charParams l="1605" t="656" r="1620" b="677">g</charParams>
+<charParams l="1624" t="655" r="1638" b="671">e</charParams>
+<charParams l="1639" t="649" r="1654" b="671"> </charParams>
+<charParams l="1655" t="649" r="1674" b="671">V</charParams>
+<charParams l="1678" t="655" r="1693" b="671">e</charParams>
+<charParams l="1696" t="655" r="1710" b="671">n</charParams>
+<charParams l="1712" t="649" r="1723" b="671">t</charParams>
+<charParams l="1725" t="649" r="1729" b="671">i</charParams>
+<charParams l="1734" t="650" r="1737" b="671">l</charParams>
+<charParams l="1742" t="656" r="1756" b="671">e</charParams></formatting></line>
+<line baseline="718" l="571" t="690" r="1756" b="723"><formatting lang="OldGerman">
+<charParams l="571" t="692" r="590" b="713">K</charParams>
+<charParams l="594" t="692" r="611" b="715">S</charParams>
+<charParams l="615" t="704" r="622" b="708">-</charParams>
+<charParams l="627" t="692" r="645" b="713">A</charParams>
+<charParams l="649" t="692" r="653" b="713" suspicious="1">l</charParams>
+<charParams l="657" t="698" r="671" b="715">u</charParams>
+<charParams l="674" t="698" r="687" b="714">s</charParams>
+<charParams l="691" t="695" r="694" b="714">i</charParams>
+<charParams l="699" t="693" r="702" b="713" suspicious="1">l</charParams>
+<charParams l="706" t="705" r="713" b="708">-</charParams>
+<charParams l="718" t="692" r="737" b="714">N</charParams>
+<charParams l="741" t="698" r="755" b="714">e</charParams>
+<charParams l="760" t="693" r="763" b="714" suspicious="1">l</charParams>
+<charParams l="767" t="698" r="780" b="715">s</charParams>
+<charParams l="783" t="698" r="799" b="715">o</charParams>
+<charParams l="803" t="698" r="816" b="715">n</charParams>
+<charParams l="820" t="705" r="826" b="709">-</charParams>
+<charParams l="832" t="693" r="850" b="714">B</charParams>
+<charParams l="853" t="698" r="869" b="715">o</charParams>
+<charParams l="873" t="694" r="886" b="714">h</charParams>
+<charParams l="891" t="698" r="904" b="714">n</charParams>
+<charParams l="908" t="698" r="923" b="715">a</charParams>
+<charParams l="926" t="693" r="930" b="714" suspicious="1">l</charParams>
+<charParams l="935" t="693" r="938" b="714">i</charParams>
+<charParams l="941" t="693" r="951" b="714">t</charParams>
+<charParams l="954" t="698" r="968" b="715">e</charParams>
+<charParams l="972" t="710" r="976" b="719" suspicious="1">,</charParams>
+<charParams l="977" t="693" r="998" b="719"> </charParams>
+<charParams l="999" t="693" r="1020" b="715">G</charParams>
+<charParams l="1025" t="699" r="1033" b="714">r</charParams>
+<charParams l="1036" t="698" r="1052" b="714">a</charParams>
+<charParams l="1054" t="698" r="1068" b="716">u</charParams>
+<charParams l="1071" t="700" r="1086" b="722">g</charParams>
+<charParams l="1090" t="700" r="1103" b="715">u</charParams>
+<charParams l="1107" t="693" r="1120" b="715">ß</charParams>
+<charParams l="1123" t="705" r="1130" b="709">-</charParams>
+<charParams l="1135" t="693" r="1152" b="715">K</charParams>
+<charParams l="1156" t="699" r="1172" b="715">o</charParams>
+<charParams l="1177" t="693" r="1181" b="715">l</charParams>
+<charParams l="1186" t="693" r="1201" b="715">b</charParams>
+<charParams l="1205" t="699" r="1219" b="715">e</charParams>
+<charParams l="1223" t="699" r="1237" b="715">n</charParams>
+<charParams l="1238" t="692" r="1257" b="718"> </charParams>
+<charParams l="1258" t="692" r="1263" b="718" suspicious="1">|</charParams>
+<charParams l="1264" t="692" r="1285" b="718"> </charParams>
+<charParams l="1286" t="693" r="1304" b="715">K</charParams>
+<charParams l="1308" t="699" r="1323" b="715">o</charParams>
+<charParams l="1327" t="693" r="1331" b="714">l</charParams>
+<charParams l="1336" t="693" r="1351" b="715">b</charParams>
+<charParams l="1354" t="699" r="1369" b="715">e</charParams>
+<charParams l="1373" t="699" r="1386" b="715">n</charParams>
+<charParams l="1391" t="699" r="1399" b="714">r</charParams>
+<charParams l="1402" t="693" r="1406" b="715">i</charParams>
+<charParams l="1410" t="699" r="1424" b="716">n</charParams>
+<charParams l="1428" t="700" r="1442" b="721">g</charParams>
+<charParams l="1446" t="699" r="1461" b="716">e</charParams>
+<charParams l="1462" t="699" r="1484" b="717"> </charParams>
+<charParams l="1485" t="700" r="1499" b="716">u</charParams>
+<charParams l="1503" t="700" r="1516" b="716">n</charParams>
+<charParams l="1519" t="694" r="1535" b="716">d</charParams>
+<charParams l="1536" t="694" r="1557" b="716"> </charParams>
+<charParams l="1558" t="694" r="1576" b="716">K</charParams>
+<charParams l="1579" t="700" r="1595" b="717">o</charParams>
+<charParams l="1599" t="695" r="1603" b="716">l</charParams>
+<charParams l="1608" t="694" r="1623" b="716">b</charParams>
+<charParams l="1626" t="700" r="1640" b="716">e</charParams>
+<charParams l="1645" t="700" r="1658" b="716">n</charParams>
+<charParams l="1662" t="694" r="1677" b="716">b</charParams>
+<charParams l="1681" t="700" r="1697" b="716">o</charParams>
+<charParams l="1700" t="694" r="1704" b="716">l</charParams>
+<charParams l="1708" t="700" r="1720" b="716">z</charParams>
+<charParams l="1724" t="701" r="1738" b="716">e</charParams>
+<charParams l="1742" t="700" r="1756" b="716">n</charParams></formatting></line>
+<line baseline="764" l="283" t="738" r="574" b="766"><formatting lang="OldGerman">
+<charParams l="283" t="738" r="301" b="761">E</charParams>
+<charParams l="305" t="738" r="309" b="761">i</charParams>
+<charParams l="313" t="744" r="326" b="761">n</charParams>
+<charParams l="330" t="738" r="346" b="761">b</charParams>
+<charParams l="349" t="744" r="365" b="761">a</charParams>
+<charParams l="367" t="744" r="381" b="761">u</charParams>
+<charParams l="383" t="738" r="393" b="760">f</charParams>
+<charParams l="395" t="744" r="410" b="760">e</charParams>
+<charParams l="414" t="745" r="422" b="760">r</charParams>
+<charParams l="424" t="738" r="434" b="760">t</charParams>
+<charParams l="437" t="738" r="441" b="760">i</charParams>
+<charParams l="445" t="744" r="460" b="766">g</charParams>
+<charParams l="463" t="744" r="478" b="760">e</charParams>
+<charParams l="479" t="738" r="490" b="760"> </charParams>
+<charParams l="491" t="738" r="506" b="760">L</charParams>
+<charParams l="508" t="744" r="525" b="760">a</charParams>
+<charParams l="527" t="744" r="541" b="766">g</charParams>
+<charParams l="545" t="743" r="560" b="760">e</charParams>
+<charParams l="564" t="744" r="574" b="760">r</charParams></formatting></line>
+<line baseline="809" l="282" t="782" r="572" b="809"><formatting lang="OldGerman">
+<charParams l="282" t="783" r="297" b="805">L</charParams>
+<charParams l="300" t="788" r="316" b="805">a</charParams>
+<charParams l="319" t="789" r="332" b="808">g</charParams>
+<charParams l="335" t="789" r="351" b="805">e</charParams>
+<charParams l="355" t="789" r="364" b="804">r</charParams>
+<charParams l="365" t="789" r="372" b="804"> </charParams>
+<charParams l="373" t="795" r="381" b="800">-</charParams>
+<charParams l="382" t="783" r="393" b="805"> </charParams>
+<charParams l="394" t="783" r="413" b="805">B</charParams>
+<charParams l="416" t="789" r="431" b="805">e</charParams>
+<charParams l="434" t="788" r="450" b="805">a</charParams>
+<charParams l="453" t="789" r="461" b="804">r</charParams>
+<charParams l="465" t="782" r="480" b="804">b</charParams>
+<charParams l="484" t="788" r="498" b="804">e</charParams>
+<charParams l="503" t="783" r="507" b="803">i</charParams>
+<charParams l="509" t="783" r="520" b="804">t</charParams>
+<charParams l="522" t="788" r="535" b="805">u</charParams>
+<charParams l="540" t="788" r="553" b="805">n</charParams>
+<charParams l="557" t="789" r="572" b="809">g</charParams></formatting></line></par>
+<par align="Right" lineSpacing="1080">
+<line baseline="852" l="569" t="824" r="1757" b="857"><formatting lang="OldGerman">
+<charParams l="569" t="827" r="589" b="848">A</charParams>
+<charParams l="592" t="833" r="605" b="849">u</charParams>
+<charParams l="608" t="832" r="621" b="849">s</charParams>
+<charParams l="625" t="832" r="638" b="848">s</charParams>
+<charParams l="641" t="832" r="656" b="855">p</charParams>
+<charParams l="660" t="834" r="669" b="849">r</charParams>
+<charParams l="671" t="828" r="676" b="849">i</charParams>
+<charParams l="679" t="827" r="688" b="849">t</charParams>
+<charParams l="691" t="834" r="703" b="849">z</charParams>
+<charParams l="707" t="833" r="721" b="850">e</charParams>
+<charParams l="725" t="834" r="738" b="850">n</charParams>
+<charParams l="739" t="834" r="754" b="850"> </charParams>
+<charParams l="755" t="835" r="768" b="850">u</charParams>
+<charParams l="772" t="834" r="785" b="850">n</charParams>
+<charParams l="790" t="828" r="805" b="850">d</charParams>
+<charParams l="806" t="828" r="822" b="850"> </charParams>
+<charParams l="823" t="829" r="840" b="849">A</charParams>
+<charParams l="845" t="834" r="858" b="850">u</charParams>
+<charParams l="862" t="834" r="875" b="850">s</charParams>
+<charParams l="879" t="828" r="893" b="850">d</charParams>
+<charParams l="898" t="834" r="906" b="849">r</charParams>
+<charParams l="909" t="834" r="924" b="850">e</charParams>
+<charParams l="927" t="828" r="941" b="849">h</charParams>
+<charParams l="945" t="835" r="960" b="851">e</charParams>
+<charParams l="963" t="834" r="976" b="850">n</charParams>
+<charParams l="977" t="834" r="993" b="850"> </charParams>
+<charParams l="994" t="834" r="1007" b="850">v</charParams>
+<charParams l="1010" t="834" r="1025" b="850">o</charParams>
+<charParams l="1029" t="834" r="1042" b="850">n</charParams>
+<charParams l="1043" t="828" r="1059" b="851"> </charParams>
+<charParams l="1060" t="829" r="1074" b="851">L</charParams>
+<charParams l="1078" t="835" r="1094" b="850">a</charParams>
+<charParams l="1096" t="835" r="1110" b="855">g</charParams>
+<charParams l="1115" t="835" r="1129" b="850">e</charParams>
+<charParams l="1133" t="836" r="1141" b="849">r</charParams>
+<charParams l="1145" t="835" r="1158" b="850">n</charParams>
+<charParams l="1159" t="835" r="1175" b="851"> </charParams>
+<charParams l="1176" t="835" r="1189" b="851">u</charParams>
+<charParams l="1193" t="834" r="1206" b="850">n</charParams>
+<charParams l="1210" t="829" r="1225" b="850">d</charParams>
+<charParams l="1226" t="829" r="1243" b="851"> </charParams>
+<charParams l="1244" t="829" r="1261" b="851">P</charParams>
+<charParams l="1265" t="829" r="1268" b="850">l</charParams>
+<charParams l="1272" t="834" r="1287" b="851">e</charParams>
+<charParams l="1291" t="835" r="1304" b="851">u</charParams>
+<charParams l="1307" t="834" r="1322" b="851">e</charParams>
+<charParams l="1326" t="829" r="1329" b="850">l</charParams>
+<charParams l="1334" t="834" r="1346" b="850">s</charParams>
+<charParams l="1348" t="829" r="1359" b="850">t</charParams>
+<charParams l="1362" t="834" r="1377" b="850">a</charParams>
+<charParams l="1380" t="834" r="1393" b="850">n</charParams>
+<charParams l="1397" t="834" r="1411" b="856">g</charParams>
+<charParams l="1416" t="834" r="1430" b="850">e</charParams>
+<charParams l="1434" t="834" r="1447" b="850">n</charParams>
+<charParams l="1448" t="826" r="1458" b="850"> </charParams>
+<charParams l="1459" t="826" r="1466" b="851">/</charParams>
+<charParams l="1467" t="827" r="1477" b="851"> </charParams>
+<charParams l="1478" t="829" r="1506" b="851">W</charParams>
+<charParams l="1509" t="836" r="1524" b="851">e</charParams>
+<charParams l="1528" t="836" r="1537" b="851">r</charParams>
+<charParams l="1540" t="829" r="1553" b="851">k</charParams>
+<charParams l="1557" t="835" r="1570" b="851">s</charParams>
+<charParams l="1572" t="829" r="1583" b="851">t</charParams>
+<charParams l="1585" t="830" r="1600" b="851">ä</charParams>
+<charParams l="1602" t="829" r="1611" b="851">t</charParams>
+<charParams l="1612" t="829" r="1623" b="851">t</charParams>
+<charParams l="1626" t="835" r="1641" b="852">e</charParams>
+<charParams l="1644" t="835" r="1657" b="851">n</charParams>
+<charParams l="1658" t="829" r="1661" b="851"> </charParams>
+<charParams l="1662" t="829" r="1677" b="851">b</charParams>
+<charParams l="1681" t="835" r="1695" b="851">e</charParams>
+<charParams l="1699" t="829" r="1714" b="851">d</charParams>
+<charParams l="1718" t="835" r="1734" b="851">a</charParams>
+<charParams l="1737" t="836" r="1747" b="851">r</charParams>
+<charParams l="1747" t="829" r="1757" b="851">f</charParams></formatting></line></par>
+</text>
+</block>
+<block blockType="Text" l="251" t="1033" r="1787" b="1707"><region><rect l="252" t="1033" r="655" b="1034"/><rect l="252" t="1034" r="1059" b="1035"/><rect l="252" t="1035" r="1464" b="1036"/><rect l="252" t="1036" r="1787" b="1390"/><rect l="251" t="1390" r="1787" b="1394"/><rect l="251" t="1394" r="1786" b="1704"/><rect l="651" t="1704" r="1786" b="1705"/><rect l="1056" t="1705" r="1786" b="1706"/><rect l="1460" t="1706" r="1786" b="1707"/></region>
+<text>
+<par lineSpacing="3650">
+<line baseline="1198" l="259" t="1038" r="1779" b="1313"><formatting lang="OldGerman">
+<charParams l="259" t="1074" r="355" b="1170" suspicious="1">9</charParams>
+<charParams l="347" t="1118" r="391" b="1170">r</charParams>
+<charParams l="399" t="1114" r="455" b="1170" suspicious="1">a</charParams>
+<charParams l="467" t="1114" r="523" b="1170">n</charParams>
+<charParams l="535" t="1114" r="587" b="1170">z</charParams>
+<charParams l="588" t="1042" r="638" b="1254"> </charParams>
+<charParams l="639" t="1042" r="763" b="1255" suspicious="1">^</charParams>
+<charParams l="703" t="1039" r="807" b="1251" suspicious="1">J</charParams>
+<charParams l="795" t="1079" r="835" b="1211" suspicious="1">\</charParams>
+<charParams l="823" t="1043" r="931" b="1255" suspicious="1">f</charParams>
+<charParams l="895" t="1135" r="991" b="1255" suspicious="1">e</charParams>
+<charParams l="1011" t="1139" r="1127" b="1256" suspicious="1">U</charParams>
+<charParams l="1135" t="1140" r="1315" b="1256" suspicious="1">m</charParams>
+<charParams l="1335" t="1140" r="1431" b="1256" suspicious="1">e</charParams>
+<charParams l="1423" t="1140" r="1563" b="1313" suspicious="1">y</charParams>
+<charParams l="1575" t="1141" r="1675" b="1257" suspicious="1">e</charParams>
+<charParams l="1687" t="1141" r="1779" b="1253" suspicious="1">r</charParams></formatting></line></par>
+<par align="Center" rightIndent="100" lineSpacing="1660">
+<line baseline="1369" l="636" t="1310" r="1417" b="1381"><formatting lang="OldGerman">
+<charParams l="636" t="1310" r="689" b="1380" suspicious="1">G</charParams>
+<charParams l="705" t="1335" r="736" b="1365">a</charParams>
+<charParams l="763" t="1336" r="787" b="1365">r</charParams>
+<charParams l="808" t="1323" r="827" b="1366">t</charParams>
+<charParams l="851" t="1335" r="877" b="1366">e</charParams>
+<charParams l="901" t="1336" r="934" b="1366">n</charParams>
+<charParams l="961" t="1314" r="991" b="1366">b</charParams>
+<charParams l="1012" t="1335" r="1043" b="1366">a</charParams>
+<charParams l="1065" t="1337" r="1097" b="1366">u</charParams>
+<charParams l="1124" t="1315" r="1154" b="1367">b</charParams>
+<charParams l="1175" t="1336" r="1202" b="1367">e</charParams>
+<charParams l="1220" t="1324" r="1239" b="1366">t</charParams>
+<charParams l="1259" t="1337" r="1285" b="1367">r</charParams>
+<charParams l="1305" t="1321" r="1322" b="1367">i</charParams>
+<charParams l="1341" t="1337" r="1367" b="1368">e</charParams>
+<charParams l="1387" t="1316" r="1417" b="1367">b</charParams></formatting></line></par>
+<par leftIndent="9200" lineSpacing="1272">
+<line baseline="1450" l="636" t="1419" r="1415" b="1456"><formatting lang="OldGerman">
+<charParams l="636" t="1420" r="665" b="1447">H</charParams>
+<charParams l="666" t="1427" r="684" b="1447">a</charParams>
+<charParams l="687" t="1427" r="704" b="1447">u</charParams>
+<charParams l="703" t="1428" r="725" b="1454">p</charParams>
+<charParams l="727" t="1422" r="737" b="1447">t</charParams>
+<charParams l="736" t="1428" r="759" b="1455">g</charParams>
+<charParams l="758" t="1427" r="773" b="1447">e</charParams>
+<charParams l="774" t="1428" r="789" b="1446">s</charParams>
+<charParams l="792" t="1428" r="807" b="1447">c</charParams>
+<charParams l="803" t="1420" r="821" b="1447">h</charParams>
+<charParams l="824" t="1421" r="843" b="1446">ä</charParams>
+<charParams l="838" t="1420" r="860" b="1455">f</charParams>
+<charParams l="858" t="1422" r="869" b="1448">t</charParams>
+<charParams l="875" t="1429" r="884" b="1448">:</charParams>
+<charParams l="885" t="1422" r="911" b="1448"> </charParams>
+<charParams l="912" t="1422" r="937" b="1448">F</charParams>
+<charParams l="942" t="1427" r="958" b="1447">e</charParams>
+<charParams l="966" t="1421" r="976" b="1447">l</charParams>
+<charParams l="982" t="1421" r="1002" b="1447">d</charParams>
+<charParams l="1009" t="1420" r="1028" b="1447">k</charParams>
+<charParams l="1036" t="1421" r="1047" b="1447">i</charParams>
+<charParams l="1053" t="1428" r="1068" b="1448">r</charParams>
+<charParams l="1075" t="1429" r="1090" b="1448">c</charParams>
+<charParams l="1097" t="1422" r="1115" b="1448">h</charParams>
+<charParams l="1124" t="1429" r="1142" b="1448">n</charParams>
+<charParams l="1151" t="1429" r="1166" b="1448">e</charParams>
+<charParams l="1174" t="1429" r="1189" b="1448">r</charParams>
+<charParams l="1190" t="1421" r="1215" b="1449"> </charParams>
+<charParams l="1216" t="1421" r="1239" b="1449">S</charParams>
+<charParams l="1245" t="1423" r="1256" b="1448">t</charParams>
+<charParams l="1262" t="1428" r="1278" b="1448">r</charParams>
+<charParams l="1284" t="1428" r="1303" b="1448">a</charParams>
+<charParams l="1306" t="1421" r="1331" b="1456">ß</charParams>
+<charParams l="1338" t="1429" r="1353" b="1448">e</charParams>
+<charParams l="1354" t="1422" r="1378" b="1448"> </charParams>
+<charParams l="1379" t="1422" r="1392" b="1448">1</charParams>
+<charParams l="1393" t="1422" r="1415" b="1448">5</charParams></formatting></line>
+<line baseline="1503" l="637" t="1472" r="1414" b="1509"><formatting lang="OldGerman">
+<charParams l="637" t="1473" r="663" b="1500">Z</charParams>
+<charParams l="662" t="1481" r="686" b="1500">w</charParams>
+<charParams l="687" t="1481" r="702" b="1500">e</charParams>
+<charParams l="704" t="1473" r="714" b="1500">i</charParams>
+<charParams l="713" t="1481" r="736" b="1507">g</charParams>
+<charParams l="736" t="1473" r="753" b="1500">b</charParams>
+<charParams l="754" t="1480" r="769" b="1500">e</charParams>
+<charParams l="770" t="1474" r="781" b="1499">t</charParams>
+<charParams l="783" t="1480" r="798" b="1500">r</charParams>
+<charParams l="798" t="1473" r="809" b="1500">i</charParams>
+<charParams l="810" t="1480" r="825" b="1500">e</charParams>
+<charParams l="827" t="1473" r="843" b="1500">b</charParams>
+<charParams l="844" t="1473" r="857" b="1500"> </charParams>
+<charParams l="858" t="1481" r="876" b="1500">u</charParams>
+<charParams l="878" t="1481" r="896" b="1500">n</charParams>
+<charParams l="898" t="1475" r="917" b="1500">d</charParams>
+<charParams l="918" t="1475" r="934" b="1501"> </charParams>
+<charParams l="935" t="1475" r="958" b="1501">V</charParams>
+<charParams l="956" t="1481" r="971" b="1500">e</charParams>
+<charParams l="973" t="1481" r="988" b="1500">r</charParams>
+<charParams l="989" t="1473" r="1007" b="1500">k</charParams>
+<charParams l="1009" t="1481" r="1027" b="1500">a</charParams>
+<charParams l="1030" t="1481" r="1047" b="1500">u</charParams>
+<charParams l="1043" t="1473" r="1066" b="1509">f</charParams>
+<charParams l="1070" t="1484" r="1078" b="1502">:</charParams>
+<charParams l="1079" t="1475" r="1091" b="1502"> </charParams>
+<charParams l="1092" t="1475" r="1115" b="1502" suspicious="1">S</charParams>
+<charParams l="1122" t="1482" r="1137" b="1501" suspicious="1">c</charParams>
+<charParams l="1144" t="1475" r="1162" b="1501">h</charParams>
+<charParams l="1172" t="1482" r="1195" b="1501" suspicious="1">w</charParams>
+<charParams l="1203" t="1482" r="1221" b="1501" suspicious="1">a</charParams>
+<charParams l="1229" t="1482" r="1245" b="1501">r</charParams>
+<charParams l="1250" t="1482" r="1267" b="1501">z</charParams>
+<charParams l="1274" t="1483" r="1289" b="1502" suspicious="1">e</charParams>
+<charParams l="1300" t="1482" r="1315" b="1501" suspicious="1">r</charParams>
+<charParams l="1316" t="1476" r="1332" b="1503"> </charParams>
+<charParams l="1333" t="1476" r="1367" b="1503">W</charParams>
+<charParams l="1370" t="1482" r="1385" b="1501">e</charParams>
+<charParams l="1390" t="1482" r="1414" b="1509">g</charParams></formatting></line></par>
+<par leftIndent="9200" lineSpacing="1160">
+<line baseline="1579" l="635" t="1542" r="1769" b="1587"><formatting lang="OldGerman">
+<charParams l="635" t="1542" r="665" b="1575">B</charParams>
+<charParams l="668" t="1543" r="679" b="1575">l</charParams>
+<charParams l="681" t="1552" r="702" b="1575">u</charParams>
+<charParams l="703" t="1552" r="734" b="1575">m</charParams>
+<charParams l="737" t="1552" r="754" b="1574">e</charParams>
+<charParams l="755" t="1552" r="776" b="1575">n</charParams>
+<charParams l="778" t="1552" r="795" b="1575">s</charParams>
+<charParams l="797" t="1553" r="813" b="1575">c</charParams>
+<charParams l="809" t="1543" r="830" b="1575">h</charParams>
+<charParams l="833" t="1553" r="864" b="1575">m</charParams>
+<charParams l="868" t="1552" r="887" b="1575">u</charParams>
+<charParams l="890" t="1553" r="907" b="1575">c</charParams>
+<charParams l="903" t="1543" r="925" b="1575">k</charParams>
+<charParams l="926" t="1543" r="941" b="1585"> </charParams>
+<charParams l="942" t="1543" r="968" b="1585">f</charParams>
+<charParams l="964" t="1545" r="985" b="1575">ü</charParams>
+<charParams l="987" t="1553" r="1005" b="1575">r</charParams>
+<charParams l="1006" t="1544" r="1025" b="1575"> </charParams>
+<charParams l="1026" t="1544" r="1057" b="1576">F</charParams>
+<charParams l="1058" t="1553" r="1076" b="1576" suspicious="1">r</charParams>
+<charParams l="1080" t="1553" r="1097" b="1575">e</charParams>
+<charParams l="1104" t="1554" r="1124" b="1576">u</charParams>
+<charParams l="1131" t="1544" r="1154" b="1576">d</charParams>
+<charParams l="1155" t="1544" r="1177" b="1576"> </charParams>
+<charParams l="1178" t="1553" r="1198" b="1576">u</charParams>
+<charParams l="1200" t="1553" r="1220" b="1575">n</charParams>
+<charParams l="1223" t="1544" r="1246" b="1576">d</charParams>
+<charParams l="1247" t="1544" r="1268" b="1576"> </charParams>
+<charParams l="1269" t="1544" r="1293" b="1576">L</charParams>
+<charParams l="1300" t="1554" r="1317" b="1576">e</charParams>
+<charParams l="1323" t="1545" r="1336" b="1576">i</charParams>
+<charParams l="1340" t="1545" r="1363" b="1576">d</charParams>
+<charParams l="1364" t="1545" r="1393" b="1576"> </charParams>
+<charParams l="1394" t="1553" r="1414" b="1576">a</charParams>
+<charParams l="1417" t="1554" r="1438" b="1576">u</charParams>
+<charParams l="1439" t="1554" r="1455" b="1576">c</charParams>
+<charParams l="1449" t="1545" r="1473" b="1578">h</charParams>
+<charParams l="1474" t="1546" r="1497" b="1578"> </charParams>
+<charParams l="1498" t="1555" r="1518" b="1578">n</charParams>
+<charParams l="1521" t="1556" r="1543" b="1578">a</charParams>
+<charParams l="1544" t="1556" r="1557" b="1578">c</charParams>
+<charParams l="1551" t="1546" r="1577" b="1579">h</charParams>
+<charParams l="1578" t="1546" r="1604" b="1579"> </charParams>
+<charParams l="1605" t="1556" r="1626" b="1579">a</charParams>
+<charParams l="1628" t="1556" r="1649" b="1579">u</charParams>
+<charParams l="1650" t="1556" r="1668" b="1579">s</charParams>
+<charParams l="1671" t="1556" r="1697" b="1579">w</charParams>
+<charParams l="1699" t="1549" r="1720" b="1579">ä</charParams>
+<charParams l="1722" t="1557" r="1740" b="1579">r</charParams>
+<charParams l="1739" t="1550" r="1752" b="1580">t</charParams>
+<charParams l="1751" t="1557" r="1769" b="1580">s</charParams></formatting></line></par>
+<par align="Right" lineSpacing="1296">
+<line baseline="1641" l="636" t="1614" r="1768" b="1645"><formatting lang="OldGerman">
+<charParams l="636" t="1615" r="657" b="1637">K</charParams>
+<charParams l="659" t="1617" r="673" b="1637">ü</charParams>
+<charParams l="675" t="1622" r="690" b="1638">n</charParams>
+<charParams l="692" t="1622" r="705" b="1637">s</charParams>
+<charParams l="707" t="1617" r="716" b="1638">t</charParams>
+<charParams l="718" t="1616" r="726" b="1637">l</charParams>
+<charParams l="727" t="1622" r="739" b="1638">e</charParams>
+<charParams l="740" t="1622" r="753" b="1638">r</charParams>
+<charParams l="755" t="1616" r="763" b="1638">i</charParams>
+<charParams l="764" t="1622" r="776" b="1637">s</charParams>
+<charParams l="777" t="1622" r="789" b="1637">c</charParams>
+<charParams l="787" t="1616" r="801" b="1637">h</charParams>
+<charParams l="804" t="1622" r="816" b="1638">e</charParams>
+<charParams l="817" t="1616" r="830" b="1638"> </charParams>
+<charParams l="831" t="1616" r="851" b="1637">B</charParams>
+<charParams l="852" t="1616" r="861" b="1637">i</charParams>
+<charParams l="862" t="1622" r="877" b="1637">n</charParams>
+<charParams l="879" t="1616" r="896" b="1638">d</charParams>
+<charParams l="896" t="1622" r="908" b="1638">e</charParams>
+<charParams l="910" t="1622" r="923" b="1638">r</charParams>
+<charParams l="924" t="1622" r="936" b="1638">e</charParams>
+<charParams l="937" t="1616" r="946" b="1638">i</charParams>
+<charParams l="947" t="1622" r="959" b="1637">e</charParams>
+<charParams l="961" t="1622" r="976" b="1638">n</charParams>
+<charParams l="977" t="1616" r="986" b="1643"> </charParams>
+<charParams l="987" t="1616" r="1001" b="1643">j</charParams>
+<charParams l="1002" t="1622" r="1014" b="1638">e</charParams>
+<charParams l="1015" t="1616" r="1031" b="1638">d</charParams>
+<charParams l="1032" t="1622" r="1044" b="1637">e</charParams>
+<charParams l="1046" t="1622" r="1058" b="1638">r</charParams>
+<charParams l="1059" t="1617" r="1067" b="1638"> </charParams>
+<charParams l="1068" t="1617" r="1086" b="1638">A</charParams>
+<charParams l="1090" t="1623" r="1102" b="1638">r</charParams>
+<charParams l="1105" t="1618" r="1114" b="1638">t</charParams>
+<charParams l="1115" t="1618" r="1122" b="1640"> </charParams>
+<charParams l="1123" t="1628" r="1141" b="1640" suspicious="1">*</charParams>
+<charParams l="1142" t="1616" r="1149" b="1640"> </charParams>
+<charParams l="1150" t="1616" r="1168" b="1638">S</charParams>
+<charParams l="1170" t="1619" r="1180" b="1639">t</charParams>
+<charParams l="1181" t="1617" r="1190" b="1639">i</charParams>
+<charParams l="1191" t="1618" r="1199" b="1639">l</charParams>
+<charParams l="1201" t="1623" r="1213" b="1638">v</charParams>
+<charParams l="1214" t="1623" r="1227" b="1638">o</charParams>
+<charParams l="1230" t="1617" r="1238" b="1638">l</charParams>
+<charParams l="1240" t="1617" r="1248" b="1638">l</charParams>
+<charParams l="1249" t="1623" r="1261" b="1638">e</charParams>
+<charParams l="1262" t="1617" r="1270" b="1638"> </charParams>
+<charParams l="1271" t="1617" r="1294" b="1638">D</charParams>
+<charParams l="1295" t="1623" r="1307" b="1638">e</charParams>
+<charParams l="1308" t="1617" r="1324" b="1639">k</charParams>
+<charParams l="1325" t="1623" r="1338" b="1638">o</charParams>
+<charParams l="1341" t="1623" r="1353" b="1639">r</charParams>
+<charParams l="1354" t="1623" r="1369" b="1639">a</charParams>
+<charParams l="1373" t="1619" r="1382" b="1639">t</charParams>
+<charParams l="1383" t="1617" r="1392" b="1639">i</charParams>
+<charParams l="1393" t="1623" r="1407" b="1639">o</charParams>
+<charParams l="1409" t="1623" r="1423" b="1639">n</charParams>
+<charParams l="1426" t="1623" r="1438" b="1639">e</charParams>
+<charParams l="1440" t="1623" r="1454" b="1639">n</charParams>
+<charParams l="1455" t="1618" r="1460" b="1644"> </charParams>
+<charParams l="1461" t="1618" r="1479" b="1645">f</charParams>
+<charParams l="1479" t="1621" r="1493" b="1641">ü</charParams>
+<charParams l="1495" t="1625" r="1508" b="1640">r</charParams>
+<charParams l="1509" t="1625" r="1517" b="1641"> </charParams>
+<charParams l="1518" t="1625" r="1533" b="1641">a</charParams>
+<charParams l="1535" t="1620" r="1544" b="1641">l</charParams>
+<charParams l="1545" t="1619" r="1554" b="1641">l</charParams>
+<charParams l="1554" t="1625" r="1567" b="1641">e</charParams>
+<charParams l="1568" t="1620" r="1572" b="1641"> </charParams>
+<charParams l="1573" t="1620" r="1594" b="1641">F</charParams>
+<charParams l="1593" t="1625" r="1605" b="1641">e</charParams>
+<charParams l="1606" t="1620" r="1615" b="1641">i</charParams>
+<charParams l="1616" t="1626" r="1628" b="1641">e</charParams>
+<charParams l="1629" t="1626" r="1642" b="1641">r</charParams>
+<charParams l="1643" t="1620" r="1651" b="1641">l</charParams>
+<charParams l="1652" t="1620" r="1661" b="1641">i</charParams>
+<charParams l="1662" t="1626" r="1673" b="1641">c</charParams>
+<charParams l="1669" t="1620" r="1687" b="1642">h</charParams>
+<charParams l="1689" t="1620" r="1704" b="1642">k</charParams>
+<charParams l="1705" t="1626" r="1717" b="1642">e</charParams>
+<charParams l="1718" t="1621" r="1727" b="1642">i</charParams>
+<charParams l="1729" t="1621" r="1739" b="1642">t</charParams>
+<charParams l="1740" t="1626" r="1752" b="1642">e</charParams>
+<charParams l="1753" t="1626" r="1768" b="1642">n</charParams></formatting></line>
+<line baseline="1695" l="257" t="1669" r="1768" b="1701"><formatting lang="OldGerman">
+<charParams l="257" t="1671" r="275" b="1692">A</charParams>
+<charParams l="279" t="1676" r="292" b="1692">r</charParams>
+<charParams l="293" t="1677" r="303" b="1692">c</charParams>
+<charParams l="302" t="1671" r="317" b="1692">h</charParams>
+<charParams l="319" t="1671" r="328" b="1692">i</charParams>
+<charParams l="330" t="1672" r="340" b="1692">t</charParams>
+<charParams l="341" t="1676" r="353" b="1692">e</charParams>
+<charParams l="354" t="1671" r="369" b="1692">k</charParams>
+<charParams l="371" t="1671" r="381" b="1692">t</charParams>
+<charParams l="382" t="1676" r="396" b="1691">o</charParams>
+<charParams l="397" t="1676" r="413" b="1691">n</charParams>
+<charParams l="416" t="1670" r="424" b="1691">i</charParams>
+<charParams l="425" t="1676" r="437" b="1691">s</charParams>
+<charParams l="438" t="1676" r="450" b="1691">c</charParams>
+<charParams l="447" t="1670" r="463" b="1691">h</charParams>
+<charParams l="465" t="1675" r="477" b="1691">e</charParams>
+<charParams l="478" t="1669" r="493" b="1691"> </charParams>
+<charParams l="494" t="1669" r="513" b="1690">G</charParams>
+<charParams l="514" t="1675" r="527" b="1691">e</charParams>
+<charParams l="527" t="1675" r="540" b="1690">s</charParams>
+<charParams l="542" t="1670" r="551" b="1690">t</charParams>
+<charParams l="552" t="1675" r="567" b="1691">a</charParams>
+<charParams l="569" t="1670" r="578" b="1690">l</charParams>
+<charParams l="580" t="1671" r="589" b="1691">t</charParams>
+<charParams l="591" t="1675" r="606" b="1690">u</charParams>
+<charParams l="609" t="1675" r="623" b="1690">n</charParams>
+<charParams l="624" t="1675" r="642" b="1696">g</charParams>
+<charParams l="643" t="1675" r="656" b="1697"> </charParams>
+<charParams l="657" t="1676" r="669" b="1691">v</charParams>
+<charParams l="670" t="1676" r="684" b="1691">o</charParams>
+<charParams l="687" t="1676" r="701" b="1691">n</charParams>
+<charParams l="702" t="1670" r="716" b="1691"> </charParams>
+<charParams l="717" t="1670" r="737" b="1691">G</charParams>
+<charParams l="739" t="1676" r="754" b="1692">a</charParams>
+<charParams l="756" t="1676" r="769" b="1691">r</charParams>
+<charParams l="772" t="1672" r="781" b="1691">t</charParams>
+<charParams l="782" t="1676" r="794" b="1692">e</charParams>
+<charParams l="795" t="1676" r="811" b="1691">n</charParams>
+<charParams l="813" t="1682" r="823" b="1685">-</charParams>
+<charParams l="824" t="1676" r="838" b="1691"> </charParams>
+<charParams l="839" t="1676" r="854" b="1691">u</charParams>
+<charParams l="856" t="1676" r="871" b="1691">n</charParams>
+<charParams l="873" t="1670" r="889" b="1691">d</charParams>
+<charParams l="890" t="1670" r="903" b="1691"> </charParams>
+<charParams l="904" t="1676" r="916" b="1691">s</charParams>
+<charParams l="917" t="1676" r="931" b="1691">o</charParams>
+<charParams l="934" t="1676" r="948" b="1691">n</charParams>
+<charParams l="950" t="1676" r="963" b="1691">s</charParams>
+<charParams l="965" t="1671" r="974" b="1691">t</charParams>
+<charParams l="976" t="1670" r="985" b="1691">i</charParams>
+<charParams l="984" t="1676" r="1002" b="1697">g</charParams>
+<charParams l="1003" t="1676" r="1015" b="1691">e</charParams>
+<charParams l="1017" t="1675" r="1031" b="1691">n</charParams>
+<charParams l="1032" t="1670" r="1051" b="1691"> </charParams>
+<charParams l="1052" t="1670" r="1070" b="1692">A</charParams>
+<charParams l="1074" t="1677" r="1088" b="1692">n</charParams>
+<charParams l="1091" t="1672" r="1099" b="1692">l</charParams>
+<charParams l="1100" t="1677" r="1115" b="1692">a</charParams>
+<charParams l="1115" t="1677" r="1134" b="1698">g</charParams>
+<charParams l="1134" t="1677" r="1146" b="1692">e</charParams>
+<charParams l="1148" t="1677" r="1162" b="1692">n</charParams>
+<charParams l="1163" t="1677" r="1182" b="1693"> </charParams>
+<charParams l="1183" t="1677" r="1197" b="1693">n</charParams>
+<charParams l="1200" t="1677" r="1215" b="1692">a</charParams>
+<charParams l="1217" t="1677" r="1227" b="1692">c</charParams>
+<charParams l="1223" t="1672" r="1241" b="1692">h</charParams>
+<charParams l="1242" t="1672" r="1261" b="1692"> </charParams>
+<charParams l="1262" t="1677" r="1277" b="1692">z</charParams>
+<charParams l="1278" t="1677" r="1291" b="1693">e</charParams>
+<charParams l="1292" t="1672" r="1300" b="1693">i</charParams>
+<charParams l="1303" t="1673" r="1312" b="1693">t</charParams>
+<charParams l="1311" t="1677" r="1329" b="1698">g</charParams>
+<charParams l="1330" t="1677" r="1342" b="1692">e</charParams>
+<charParams l="1344" t="1677" r="1366" b="1692">m</charParams>
+<charParams l="1369" t="1673" r="1385" b="1692">ä</charParams>
+<charParams l="1381" t="1671" r="1401" b="1697">ß</charParams>
+<charParams l="1402" t="1671" r="1414" b="1697"> </charParams>
+<charParams l="1415" t="1672" r="1430" b="1693">k</charParams>
+<charParams l="1432" t="1673" r="1447" b="1693">ü</charParams>
+<charParams l="1448" t="1677" r="1464" b="1694">n</charParams>
+<charParams l="1466" t="1679" r="1478" b="1694">s</charParams>
+<charParams l="1481" t="1674" r="1490" b="1694">t</charParams>
+<charParams l="1491" t="1673" r="1500" b="1694">l</charParams>
+<charParams l="1501" t="1679" r="1513" b="1694">e</charParams>
+<charParams l="1514" t="1679" r="1527" b="1694">r</charParams>
+<charParams l="1528" t="1674" r="1537" b="1694">i</charParams>
+<charParams l="1538" t="1679" r="1550" b="1694">s</charParams>
+<charParams l="1552" t="1679" r="1562" b="1694">c</charParams>
+<charParams l="1559" t="1673" r="1576" b="1694">h</charParams>
+<charParams l="1578" t="1679" r="1590" b="1695">e</charParams>
+<charParams l="1591" t="1679" r="1606" b="1695">n</charParams>
+<charParams l="1607" t="1674" r="1627" b="1695"> </charParams>
+<charParams l="1628" t="1674" r="1648" b="1695">E</charParams>
+<charParams l="1648" t="1680" r="1663" b="1695">n</charParams>
+<charParams l="1666" t="1675" r="1676" b="1696">t</charParams>
+<charParams l="1678" t="1680" r="1696" b="1696">w</charParams>
+<charParams l="1698" t="1676" r="1712" b="1696">ü</charParams>
+<charParams l="1714" t="1681" r="1727" b="1696">r</charParams>
+<charParams l="1724" t="1674" r="1741" b="1701">f</charParams>
+<charParams l="1740" t="1681" r="1752" b="1696">e</charParams>
+<charParams l="1753" t="1680" r="1768" b="1696">n</charParams></formatting></line></par>
+</text>
+</block>
+<block blockType="Text" l="270" t="1888" r="722" b="2208"><region><rect l="271" t="1888" r="655" b="1889"/><rect l="271" t="1889" r="722" b="2200"/><rect l="270" t="2200" r="722" b="2203"/><rect l="270" t="2203" r="721" b="2206"/><rect l="271" t="2206" r="721" b="2207"/><rect l="651" t="2207" r="721" b="2208"/></region>
+<text>
+<par lineSpacing="1550">
+<line baseline="1937" l="277" t="1895" r="718" b="1935"><formatting lang="OldGerman">
+<charParams l="277" t="1895" r="313" b="1934">B</charParams>
+<charParams l="335" t="1903" r="357" b="1934">r</charParams>
+<charParams l="378" t="1903" r="410" b="1934">e</charParams>
+<charParams l="433" t="1903" r="465" b="1933">n</charParams>
+<charParams l="489" t="1903" r="521" b="1933">n</charParams>
+<charParams l="544" t="1895" r="575" b="1933">h</charParams>
+<charParams l="598" t="1902" r="635" b="1934">o</charParams>
+<charParams l="657" t="1896" r="670" b="1934">l</charParams>
+<charParams l="692" t="1904" r="718" b="1934">z</charParams></formatting></line></par>
+<par lineSpacing="2136">
+<line baseline="2026" l="277" t="1983" r="622" b="2022"><formatting lang="OldGerman">
+<charParams l="277" t="1984" r="313" b="2022" suspicious="1">B</charParams>
+<charParams l="334" t="1992" r="356" b="2022" suspicious="1">r</charParams>
+<charParams l="378" t="1983" r="391" b="2022" suspicious="1">i</charParams>
+<charParams l="414" t="1983" r="447" b="2022" suspicious="1">k</charParams>
+<charParams l="468" t="1991" r="500" b="2022" suspicious="1">e</charParams>
+<charParams l="521" t="1983" r="540" b="2022" suspicious="1">t</charParams>
+<charParams l="559" t="1984" r="578" b="2022" suspicious="1">t</charParams>
+<charParams l="598" t="1992" r="622" b="2022" suspicious="1">s</charParams></formatting></line></par>
+<par lineSpacing="2136">
+<line baseline="2114" l="277" t="2071" r="570" b="2112"><formatting lang="OldGerman">
+<charParams l="277" t="2072" r="313" b="2112" suspicious="1">K</charParams>
+<charParams l="333" t="2079" r="370" b="2111" suspicious="1">o</charParams>
+<charParams l="392" t="2072" r="424" b="2110" suspicious="1">h</charParams>
+<charParams l="446" t="2071" r="460" b="2110" suspicious="1">l</charParams>
+<charParams l="483" t="2080" r="514" b="2111" suspicious="1">e</charParams>
+<charParams l="537" t="2080" r="570" b="2110" suspicious="1">n</charParams></formatting></line></par>
+<par lineSpacing="2136">
+<line baseline="2204" l="276" t="2161" r="468" b="2201"><formatting lang="OldGerman">
+<charParams l="276" t="2161" r="312" b="2200">K</charParams>
+<charParams l="332" t="2168" r="370" b="2201">o</charParams>
+<charParams l="391" t="2161" r="423" b="2199">k</charParams>
+<charParams l="442" t="2169" r="468" b="2200">s</charParams></formatting></line></par>
+</text>
+</block>
+<block blockType="Picture" l="794" t="1891" r="1226" b="2326"><region><rect l="795" t="1891" r="1059" b="1892"/><rect l="795" t="1892" r="1226" b="2200"/><rect l="794" t="2200" r="1226" b="2203"/><rect l="794" t="2203" r="1225" b="2325"/><rect l="1056" t="2325" r="1225" b="2326"/></region>
+</block>
+<block blockType="Text" l="1241" t="1889" r="1754" b="2209"><region><rect l="1242" t="1889" r="1464" b="1890"/><rect l="1242" t="1890" r="1754" b="2200"/><rect l="1241" t="2200" r="1754" b="2203"/><rect l="1241" t="2203" r="1753" b="2207"/><rect l="1242" t="2207" r="1753" b="2208"/><rect l="1460" t="2208" r="1753" b="2209"/></region>
+<text>
+<par align="Right" lineSpacing="1550">
+<line baseline="1938" l="1246" t="1895" r="1747" b="1937"><formatting lang="OldGerman">
+<charParams l="1246" t="1895" r="1272" b="1934">F</charParams>
+<charParams l="1277" t="1904" r="1308" b="1935">u</charParams>
+<charParams l="1314" t="1896" r="1344" b="1935">ß</charParams>
+<charParams l="1349" t="1895" r="1384" b="1934">b</charParams>
+<charParams l="1388" t="1902" r="1424" b="1935">o</charParams>
+<charParams l="1429" t="1896" r="1464" b="1936">d</charParams>
+<charParams l="1470" t="1905" r="1501" b="1936">e</charParams>
+<charParams l="1506" t="1906" r="1538" b="1936">n</charParams>
+<charParams l="1545" t="1897" r="1580" b="1936">b</charParams>
+<charParams l="1585" t="1906" r="1606" b="1936">r</charParams>
+<charParams l="1610" t="1906" r="1642" b="1937">e</charParams>
+<charParams l="1646" t="1898" r="1664" b="1936">t</charParams>
+<charParams l="1666" t="1898" r="1685" b="1936">t</charParams>
+<charParams l="1688" t="1905" r="1720" b="1937">e</charParams>
+<charParams l="1725" t="1906" r="1747" b="1937">r</charParams></formatting></line></par>
+<par align="Right" lineSpacing="2112">
+<line baseline="2026" l="1334" t="1984" r="1747" b="2025"><formatting lang="OldGerman">
+<charParams l="1334" t="1984" r="1369" b="2022">B</charParams>
+<charParams l="1387" t="1984" r="1400" b="2022">l</charParams>
+<charParams l="1418" t="1991" r="1455" b="2023">o</charParams>
+<charParams l="1472" t="1993" r="1494" b="2024">c</charParams>
+<charParams l="1512" t="1985" r="1543" b="2024">h</charParams>
+<charParams l="1561" t="1994" r="1607" b="2024">w</charParams>
+<charParams l="1624" t="1994" r="1655" b="2024">a</charParams>
+<charParams l="1675" t="1995" r="1696" b="2024">r</charParams>
+<charParams l="1714" t="1994" r="1747" b="2025">e</charParams></formatting></line></par>
+<par align="Right" lineSpacing="2112">
+<line baseline="2114" l="1406" t="2073" r="1746" b="2113"><formatting lang="OldGerman">
+<charParams l="1406" t="2073" r="1441" b="2111" suspicious="1">B</charParams>
+<charParams l="1463" t="2081" r="1494" b="2113" suspicious="1">a</charParams>
+<charParams l="1514" t="2082" r="1546" b="2113" suspicious="1">u</charParams>
+<charParams l="1569" t="2074" r="1601" b="2112" suspicious="1">h</charParams>
+<charParams l="1624" t="2081" r="1661" b="2113" suspicious="1">o</charParams>
+<charParams l="1684" t="2074" r="1697" b="2112" suspicious="1">l</charParams>
+<charParams l="1720" t="2083" r="1746" b="2113" suspicious="1">z</charParams></formatting></line></par>
+<par align="Right" lineSpacing="2112">
+<line baseline="2203" l="1476" t="2162" r="1745" b="2202"><formatting lang="OldGerman">
+<charParams l="1476" t="2162" r="1504" b="2201" suspicious="1">L</charParams>
+<charParams l="1526" t="2171" r="1556" b="2201" suspicious="1">a</charParams>
+<charParams l="1578" t="2163" r="1597" b="2201" suspicious="1">t</charParams>
+<charParams l="1617" t="2163" r="1636" b="2201" suspicious="1">t</charParams>
+<charParams l="1657" t="2172" r="1689" b="2202" suspicious="1">e</charParams>
+<charParams l="1713" t="2172" r="1745" b="2202" suspicious="1">n</charParams></formatting></line></par>
+</text>
+</block>
+<block blockType="Text" l="224" t="2363" r="1795" b="2481"><region><rect l="224" t="2363" r="250" b="2364"/><rect l="224" t="2364" r="655" b="2365"/><rect l="224" t="2365" r="1059" b="2366"/><rect l="224" t="2366" r="1464" b="2367"/><rect l="224" t="2367" r="1795" b="2477"/><rect l="247" t="2477" r="1795" b="2478"/><rect l="651" t="2478" r="1795" b="2479"/><rect l="1056" t="2479" r="1795" b="2480"/><rect l="1460" t="2480" r="1795" b="2481"/></region>
+<text>
+<par lineSpacing="3100">
+<line baseline="2462" l="231" t="2370" r="1791" b="2476"><formatting lang="OldGerman">
+<charParams l="231" t="2372" r="333" b="2459">R</charParams>
+<charParams l="349" t="2393" r="453" b="2459">u</charParams>
+<charParams l="465" t="2373" r="563" b="2459">d</charParams>
+<charParams l="579" t="2393" r="679" b="2462">o</charParams>
+<charParams l="693" t="2374" r="739" b="2460">l</charParams>
+<charParams l="757" t="2374" r="811" b="2460">f</charParams>
+<charParams l="812" t="2374" r="866" b="2460"> </charParams>
+<charParams l="867" t="2374" r="943" b="2460">S</charParams>
+<charParams l="957" t="2374" r="1005" b="2460" suspicious="1">i</charParams>
+<charParams l="1023" t="2392" r="1085" b="2459" suspicious="1">c</charParams>
+<charParams l="1085" t="2373" r="1185" b="2459" suspicious="1">k</charParams>
+<charParams l="1199" t="2395" r="1285" b="2461">e</charParams>
+<charParams l="1299" t="2395" r="1399" b="2459">n</charParams>
+<charParams l="1419" t="2373" r="1513" b="2460">b</charParams>
+<charParams l="1527" t="2394" r="1615" b="2462" suspicious="1">e</charParams>
+<charParams l="1625" t="2394" r="1695" b="2460">r</charParams>
+<charParams l="1705" t="2380" r="1791" b="2476" suspicious="1">g</charParams></formatting></line></par>
+</text>
+</block>
+<block blockType="Text" l="223" t="2476" r="502" b="2561"><region><rect l="223" t="2476" r="250" b="2477"/><rect l="223" t="2477" r="502" b="2560"/><rect l="247" t="2560" r="502" b="2561"/></region>
+<text>
+<par align="Justified" lineSpacing="1080">
+<line baseline="2514" l="230" t="2483" r="496" b="2516"><formatting lang="OldGerman">
+<charParams l="230" t="2483" r="251" b="2510">A</charParams>
+<charParams l="259" t="2489" r="284" b="2510">m</charParams>
+<charParams l="285" t="2484" r="305" b="2510"> </charParams>
+<charParams l="306" t="2484" r="324" b="2510" suspicious="1">B</charParams>
+<charParams l="331" t="2490" r="347" b="2510">a</charParams>
+<charParams l="355" t="2489" r="369" b="2510">c</charParams>
+<charParams l="377" t="2484" r="391" b="2509">h</charParams>
+<charParams l="400" t="2484" r="405" b="2510" suspicious="1">l</charParams>
+<charParams l="406" t="2484" r="424" b="2510"> </charParams>
+<charParams l="425" t="2488" r="442" b="2510">2</charParams>
+<charParams l="445" t="2487" r="460" b="2511" suspicious="1">3</charParams>
+<charParams l="464" t="2485" r="471" b="2499" suspicious="1">■</charParams>
+<charParams l="475" t="2484" r="484" b="2516">/</charParams>
+<charParams l="486" t="2498" r="496" b="2513" suspicious="1">»</charParams></formatting></line>
+<line baseline="2559" l="230" t="2527" r="497" b="2555"><formatting lang="OldGerman">
+<charParams l="230" t="2527" r="245" b="2553">F</charParams>
+<charParams l="256" t="2534" r="273" b="2555">e</charParams>
+<charParams l="285" t="2534" r="295" b="2554">r</charParams>
+<charParams l="306" t="2534" r="321" b="2554" suspicious="1">n</charParams>
+<charParams l="336" t="2534" r="344" b="2554" suspicious="1">r</charParams>
+<charParams l="356" t="2534" r="370" b="2555">u</charParams>
+<charParams l="382" t="2528" r="392" b="2554">f</charParams>
+<charParams l="393" t="2528" r="429" b="2555"> </charParams>
+<charParams l="430" t="2532" r="445" b="2555">3</charParams>
+<charParams l="455" t="2532" r="471" b="2555">4</charParams>
+<charParams l="480" t="2532" r="497" b="2555">6</charParams></formatting></line></par>
+</text>
+</block>
+<block blockType="Text" l="528" t="2488" r="1494" b="2563"><region><rect l="528" t="2488" r="655" b="2489"/><rect l="528" t="2489" r="1059" b="2490"/><rect l="528" t="2490" r="1464" b="2491"/><rect l="528" t="2491" r="1494" b="2560"/><rect l="651" t="2560" r="1494" b="2561"/><rect l="1056" t="2561" r="1494" b="2562"/><rect l="1460" t="2562" r="1493" b="2563"/></region>
+<text>
+<par lineSpacing="2100">
+<line baseline="2550" l="535" t="2494" r="1488" b="2556"><formatting lang="OldGerman">
+<charParams l="535" t="2495" r="583" b="2545">H</charParams>
+<charParams l="590" t="2506" r="633" b="2546">o</charParams>
+<charParams l="639" t="2495" r="653" b="2547">l</charParams>
+<charParams l="658" t="2507" r="689" b="2546">z</charParams>
+<charParams l="693" t="2517" r="713" b="2530">-</charParams>
+<charParams l="714" t="2509" r="738" b="2547"> </charParams>
+<charParams l="739" t="2509" r="777" b="2547">u</charParams>
+<charParams l="785" t="2509" r="823" b="2547">n</charParams>
+<charParams l="829" t="2496" r="872" b="2547">d</charParams>
+<charParams l="873" t="2496" r="899" b="2547"> </charParams>
+<charParams l="900" t="2496" r="947" b="2546">K</charParams>
+<charParams l="951" t="2507" r="994" b="2547">o</charParams>
+<charParams l="1000" t="2495" r="1037" b="2546">h</charParams>
+<charParams l="1045" t="2495" r="1059" b="2547">l</charParams>
+<charParams l="1066" t="2508" r="1103" b="2547">e</charParams>
+<charParams l="1108" t="2509" r="1147" b="2547">n</charParams>
+<charParams l="1154" t="2496" r="1192" b="2547">h</charParams>
+<charParams l="1197" t="2508" r="1236" b="2547">a</charParams>
+<charParams l="1242" t="2509" r="1281" b="2547">n</charParams>
+<charParams l="1287" t="2497" r="1329" b="2547">d</charParams>
+<charParams l="1337" t="2497" r="1351" b="2547">l</charParams>
+<charParams l="1358" t="2509" r="1396" b="2548">u</charParams>
+<charParams l="1403" t="2509" r="1442" b="2548">n</charParams>
+<charParams l="1448" t="2509" r="1488" b="2556">g</charParams></formatting></line></par>
+</text>
+</block>
+<block blockType="Text" l="1514" t="2480" r="1794" b="2564"><region><rect l="1514" t="2480" r="1794" b="2564"/></region>
+<text>
+<par align="Justified" lineSpacing="1080">
+<line baseline="2513" l="1520" t="2486" r="1783" b="2513"><formatting lang="OldGerman">
+<charParams l="1520" t="2487" r="1535" b="2513">J</charParams>
+<charParams l="1539" t="2493" r="1558" b="2513">o</charParams>
+<charParams l="1561" t="2487" r="1575" b="2512">h</charParams>
+<charParams l="1579" t="2492" r="1595" b="2513">a</charParams>
+<charParams l="1599" t="2493" r="1614" b="2513">n</charParams>
+<charParams l="1618" t="2493" r="1632" b="2513">n</charParams>
+<charParams l="1637" t="2493" r="1653" b="2513">e</charParams>
+<charParams l="1656" t="2493" r="1669" b="2513">s</charParams>
+<charParams l="1673" t="2493" r="1687" b="2513">s</charParams>
+<charParams l="1689" t="2488" r="1698" b="2513">t</charParams>
+<charParams l="1701" t="2493" r="1710" b="2513">r</charParams>
+<charParams l="1713" t="2492" r="1729" b="2512">a</charParams>
+<charParams l="1733" t="2487" r="1747" b="2512">ß</charParams>
+<charParams l="1750" t="2492" r="1766" b="2512">e</charParams>
+<charParams l="1767" t="2486" r="1773" b="2512" suspicious="1"> </charParams>
+<charParams l="1774" t="2486" r="1783" b="2512">1</charParams></formatting></line>
+<line baseline="2558" l="1523" t="2531" r="1789" b="2558"><formatting lang="OldGerman">
+<charParams l="1523" t="2531" r="1538" b="2558" suspicious="1">F</charParams>
+<charParams l="1549" t="2537" r="1565" b="2558" suspicious="1">e</charParams>
+<charParams l="1578" t="2537" r="1587" b="2558" suspicious="1">r</charParams>
+<charParams l="1599" t="2538" r="1613" b="2558" suspicious="1">n</charParams>
+<charParams l="1627" t="2538" r="1637" b="2558" suspicious="1">r</charParams>
+<charParams l="1648" t="2537" r="1662" b="2557" suspicious="1">u</charParams>
+<charParams l="1675" t="2532" r="1684" b="2557" suspicious="1">f</charParams>
+<charParams l="1685" t="2532" r="1718" b="2557"> </charParams>
+<charParams l="1719" t="2534" r="1735" b="2557" suspicious="1">6</charParams>
+<charParams l="1747" t="2535" r="1762" b="2558" suspicious="1">5</charParams>
+<charParams l="1773" t="2535" r="1789" b="2558" suspicious="1">5</charParams></formatting></line></par>
+</text>
+</block>
+<block blockType="SeparatorsBox" l="180" t="115" r="1860" b="927"><region><rect l="192" t="115" r="250" b="116"/><rect l="192" t="116" r="655" b="117"/><rect l="192" t="117" r="1059" b="118"/><rect l="192" t="118" r="1464" b="119"/><rect l="192" t="119" r="1856" b="120"/><rect l="192" t="120" r="1857" b="126"/><rect l="192" t="126" r="1859" b="127"/><rect l="182" t="127" r="1860" b="131"/><rect l="182" t="131" r="1860" b="132"/><rect l="182" t="132" r="1860" b="133"/><rect l="182" t="133" r="1860" b="134"/><rect l="182" t="134" r="1860" b="135"/><rect l="182" t="135" r="1860" b="136"/><rect l="182" t="136" r="1860" b="177"/><rect l="181" t="177" r="1860" b="180"/><rect l="181" t="180" r="1859" b="581"/><rect l="180" t="581" r="1859" b="584"/><rect l="180" t="584" r="1858" b="912"/><rect l="180" t="912" r="1858" b="913"/><rect l="180" t="913" r="1858" b="914"/><rect l="180" t="914" r="1858" b="915"/><rect l="180" t="915" r="1858" b="916"/><rect l="180" t="916" r="1858" b="918"/><rect l="180" t="918" r="1852" b="923"/><rect l="247" t="923" r="1852" b="924"/><rect l="651" t="924" r="1852" b="925"/><rect l="1056" t="925" r="1852" b="926"/><rect l="1460" t="926" r="1852" b="927"/></region>
+<separatorsBox>
+<separator type="Black" thickness="10"><start x="192" y="128"/><end x="1857" y="128"/>
+</separator>
+<separator type="Black" thickness="10"><start x="182" y="922"/><end x="1854" y="922"/>
+</separator>
+<separator type="Black" thickness="10"><start x="189" y="132"/><end x="189" y="928"/>
+</separator>
+<separator type="Black" thickness="10"><start x="1853" y="127"/><end x="1853" y="919"/>
+</separator>
+</separatorsBox>
+</block>
+<block blockType="SeparatorsBox" l="175" t="973" r="1856" b="1783"><region><rect l="180" t="973" r="250" b="974"/><rect l="177" t="974" r="655" b="975"/><rect l="177" t="975" r="1059" b="976"/><rect l="177" t="976" r="1464" b="977"/><rect l="177" t="977" r="1846" b="978"/><rect l="177" t="978" r="1847" b="980"/><rect l="177" t="980" r="1855" b="981"/><rect l="177" t="981" r="1856" b="986"/><rect l="176" t="986" r="1856" b="987"/><rect l="176" t="987" r="1856" b="988"/><rect l="176" t="988" r="1856" b="989"/><rect l="176" t="989" r="1855" b="990"/><rect l="176" t="990" r="1855" b="1390"/><rect l="175" t="1390" r="1855" b="1394"/><rect l="175" t="1394" r="1854" b="1765"/><rect l="175" t="1765" r="1854" b="1766"/><rect l="175" t="1766" r="1854" b="1767"/><rect l="175" t="1767" r="1854" b="1768"/><rect l="175" t="1768" r="1854" b="1769"/><rect l="175" t="1769" r="1854" b="1778"/><rect l="177" t="1778" r="1854" b="1779"/><rect l="247" t="1779" r="1854" b="1780"/><rect l="651" t="1780" r="1854" b="1781"/><rect l="1056" t="1781" r="1854" b="1782"/><rect l="1460" t="1782" r="1854" b="1783"/></region>
+<separatorsBox>
+<separator type="Black" thickness="10"><start x="182" y="984"/><end x="1849" y="984"/>
+</separator>
+<separator type="Black" thickness="10"><start x="182" y="1777"/><end x="1854" y="1777"/>
+</separator>
+<separator type="Black" thickness="10"><start x="185" y="979"/><end x="185" y="1783"/>
+</separator>
+<separator type="Black" thickness="10"><start x="1851" y="981"/><end x="1851" y="1784"/>
+</separator>
+</separatorsBox>
+</block>
+<block blockType="SeparatorsBox" l="173" t="1828" r="1850" b="2638"><region><rect l="179" t="1828" r="250" b="1829"/><rect l="178" t="1829" r="655" b="1830"/><rect l="178" t="1830" r="1059" b="1831"/><rect l="178" t="1831" r="1464" b="1832"/><rect l="178" t="1832" r="1850" b="1842"/><rect l="176" t="1842" r="1850" b="1843"/><rect l="175" t="1843" r="1850" b="1844"/><rect l="175" t="1844" r="1850" b="1845"/><rect l="175" t="1845" r="1850" b="1846"/><rect l="175" t="1846" r="1850" b="1847"/><rect l="175" t="1847" r="1849" b="2200"/><rect l="174" t="2200" r="1849" b="2203"/><rect l="174" t="2203" r="1848" b="2604"/><rect l="173" t="2604" r="1848" b="2607"/><rect l="173" t="2607" r="1847" b="2622"/><rect l="173" t="2622" r="1847" b="2623"/><rect l="173" t="2623" r="1847" b="2624"/><rect l="173" t="2624" r="1847" b="2625"/><rect l="173" t="2625" r="1847" b="2626"/><rect l="173" t="2626" r="1847" b="2634"/><rect l="247" t="2634" r="1847" b="2635"/><rect l="651" t="2635" r="1847" b="2636"/><rect l="1056" t="2636" r="1845" b="2637"/><rect l="1460" t="2637" r="1844" b="2638"/></region>
+<separatorsBox>
+<separator type="Black" thickness="9"><start x="183" y="1840"/><end x="1855" y="1840"/>
+</separator>
+<separator type="Black" thickness="9"><start x="182" y="2633"/><end x="1851" y="2633"/>
+</separator>
+<separator type="Black" thickness="9"><start x="185" y="1847"/><end x="185" y="2639"/>
+</separator>
+<separator type="Black" thickness="10"><start x="1847" y="1837"/><end x="1847" y="2637"/>
+</separator>
+</separatorsBox>
+</block>
+<block blockType="Separator" l="575" t="504" r="1758" b="515"><region><rect l="575" t="504" r="655" b="505"/><rect l="575" t="505" r="1016" b="506"/><rect l="575" t="506" r="1059" b="507"/><rect l="575" t="507" r="1294" b="508"/><rect l="575" t="508" r="1464" b="509"/><rect l="651" t="509" r="1693" b="510"/><rect l="1016" t="510" r="1758" b="511"/><rect l="1056" t="511" r="1758" b="512"/><rect l="1294" t="512" r="1758" b="513"/><rect l="1460" t="513" r="1758" b="514"/><rect l="1693" t="514" r="1758" b="515"/></region>
+<separator type="Black" thickness="5"><start x="576" y="512"/><end x="1759" y="512"/>
+</separator>
+</block>
+<block blockType="Separator" l="1983" t="1366" r="2001" b="1693"><region><rect l="1989" t="1366" r="2000" b="1376"/><rect l="1988" t="1376" r="2000" b="1377"/><rect l="1987" t="1377" r="2000" b="1390"/><rect l="1986" t="1390" r="2000" b="1394"/><rect l="1986" t="1394" r="1999" b="1398"/><rect l="1984" t="1398" r="1999" b="1401"/><rect l="1984" t="1401" r="1998" b="1403"/><rect l="1984" t="1403" r="1999" b="1405"/><rect l="1983" t="1405" r="1999" b="1408"/><rect l="1984" t="1408" r="1999" b="1409"/><rect l="1985" t="1409" r="1999" b="1428"/><rect l="1984" t="1428" r="1999" b="1432"/><rect l="1984" t="1432" r="1998" b="1435"/><rect l="1984" t="1435" r="1999" b="1436"/><rect l="1984" t="1436" r="2000" b="1438"/><rect l="1985" t="1438" r="2000" b="1475"/><rect l="1991" t="1475" r="2000" b="1476"/><rect l="1992" t="1476" r="2000" b="1477"/><rect l="1993" t="1477" r="2000" b="1478"/><rect l="1994" t="1478" r="2001" b="1499"/><rect l="1993" t="1499" r="2000" b="1547"/><rect l="1992" t="1547" r="2000" b="1567"/><rect l="1993" t="1567" r="2000" b="1576"/><rect l="1992" t="1576" r="1999" b="1584"/><rect l="1992" t="1584" r="2000" b="1590"/><rect l="1991" t="1590" r="2000" b="1594"/><rect l="1991" t="1594" r="1999" b="1693"/></region>
+<separator type="Black" thickness="9"><start x="1996" y="1366"/><end x="1996" y="1693"/>
+</separator>
+</block>
+<block blockType="Separator" l="1989" t="0" r="1999" b="237"><region><rect l="1993" t="0" r="1999" b="24"/><rect l="1992" t="24" r="1999" b="28"/><rect l="1991" t="28" r="1999" b="29"/><rect l="1990" t="29" r="1999" b="34"/><rect l="1989" t="34" r="1999" b="107"/><rect l="1989" t="107" r="1997" b="128"/><rect l="1990" t="128" r="1998" b="146"/><rect l="1991" t="146" r="1999" b="177"/><rect l="1990" t="177" r="1999" b="180"/><rect l="1990" t="180" r="1998" b="189"/><rect l="1991" t="189" r="1999" b="190"/><rect l="1992" t="190" r="1999" b="221"/><rect l="1993" t="221" r="1999" b="222"/><rect l="1993" t="222" r="1996" b="237"/></region>
+<separator type="Black" thickness="7"><start x="1994" y="0"/><end x="1994" y="237"/>
+</separator>
+</block>
+<block blockType="Separator" l="1987" t="750" r="2002" b="1104"><region><rect l="1996" t="750" r="2001" b="793"/><rect l="1995" t="793" r="2001" b="811"/><rect l="1996" t="811" r="2001" b="814"/><rect l="1995" t="814" r="2001" b="897"/><rect l="1995" t="897" r="2002" b="904"/><rect l="1995" t="904" r="2001" b="919"/><rect l="1994" t="919" r="2001" b="921"/><rect l="1993" t="921" r="2001" b="923"/><rect l="1993" t="923" r="2002" b="930"/><rect l="1993" t="930" r="2001" b="934"/><rect l="1992" t="934" r="2001" b="938"/><rect l="1992" t="938" r="2002" b="947"/><rect l="1991" t="947" r="2002" b="949"/><rect l="1991" t="949" r="2001" b="975"/><rect l="1991" t="975" r="2000" b="979"/><rect l="1992" t="979" r="2000" b="987"/><rect l="1993" t="987" r="2001" b="989"/><rect l="1993" t="989" r="2000" b="1017"/><rect l="1994" t="1017" r="2000" b="1018"/><rect l="1994" t="1018" r="1995" b="1031"/><rect l="1992" t="1031" r="1995" b="1035"/><rect l="1989" t="1035" r="1995" b="1042"/><rect l="1987" t="1042" r="1995" b="1069"/><rect l="1987" t="1069" r="2000" b="1081"/><rect l="1988" t="1081" r="2000" b="1102"/><rect l="1988" t="1102" r="2001" b="1103"/><rect l="1988" t="1103" r="1995" b="1104"/></region>
+<separator type="Black" thickness="7"><start x="1997" y="750"/><end x="1997" y="1104"/>
+</separator>
+</block>
+<block blockType="Separator" l="1990" t="2014" r="2006" b="2348"><region><rect l="1990" t="2014" r="1999" b="2052"/><rect l="1990" t="2052" r="2000" b="2053"/><rect l="1990" t="2053" r="2001" b="2054"/><rect l="1992" t="2054" r="2001" b="2055"/><rect l="1992" t="2055" r="2004" b="2061"/><rect l="1997" t="2061" r="2004" b="2062"/><rect l="1993" t="2062" r="2003" b="2066"/><rect l="1993" t="2066" r="2004" b="2067"/><rect l="1993" t="2067" r="2005" b="2131"/><rect l="1999" t="2131" r="2004" b="2135"/><rect l="1998" t="2135" r="2004" b="2136"/><rect l="1993" t="2136" r="2003" b="2155"/><rect l="1994" t="2155" r="2004" b="2156"/><rect l="1993" t="2156" r="2004" b="2158"/><rect l="1992" t="2158" r="2004" b="2200"/><rect l="1991" t="2200" r="2004" b="2203"/><rect l="1991" t="2203" r="2003" b="2258"/><rect l="1997" t="2258" r="2002" b="2261"/><rect l="1998" t="2261" r="2002" b="2262"/><rect l="1997" t="2262" r="2006" b="2286"/><rect l="2000" t="2286" r="2005" b="2296"/><rect l="1998" t="2296" r="2005" b="2304"/><rect l="1994" t="2304" r="2004" b="2318"/><rect l="1994" t="2318" r="2005" b="2326"/><rect l="1994" t="2326" r="2004" b="2328"/><rect l="1995" t="2328" r="2004" b="2332"/><rect l="1995" t="2332" r="2005" b="2348"/></region>
+<separator type="Black" thickness="10"><start x="2003" y="2014"/><end x="2003" y="2348"/>
+</separator>
+</block>
+<block blockType="Separator" l="1995" t="280" r="2005" b="471"><region><rect l="1998" t="280" r="2003" b="407"/><rect l="1998" t="407" r="2003" b="412"/><rect l="1995" t="412" r="2004" b="435"/><rect l="1996" t="435" r="2005" b="471"/></region>
+<separator type="Black" thickness="6"><start x="2001" y="280"/><end x="2001" y="471"/>
+</separator>
+</block>
+<block blockType="Separator" l="1997" t="550" r="2003" b="637"><region><rect l="1998" t="550" r="2003" b="581"/><rect l="1997" t="581" r="2003" b="584"/><rect l="1997" t="584" r="2002" b="637"/></region>
+<separator type="Black" thickness="4"><start x="2001" y="550"/><end x="2001" y="637"/>
+</separator>
+</block>
+<block blockType="Separator" l="922" t="2168" r="1056" b="2178"><region><rect l="922" t="2168" r="1055" b="2169"/><rect l="922" t="2169" r="1056" b="2178"/></region>
+<separator type="Dotted" thickness="4"><start x="927" y="2176"/><end x="1061" y="2176"/>
+</separator>
+</block>
+<block blockType="Picture" l="180" t="115" r="1860" b="927"><region><rect l="182" t="115" r="250" b="116"/><rect l="182" t="116" r="655" b="117"/><rect l="182" t="117" r="1059" b="118"/><rect l="182" t="118" r="1464" b="119"/><rect l="182" t="119" r="1859" b="120"/><rect l="182" t="120" r="1860" b="177"/><rect l="181" t="177" r="1860" b="180"/><rect l="181" t="180" r="1859" b="581"/><rect l="180" t="581" r="1859" b="584"/><rect l="180" t="584" r="1858" b="923"/><rect l="247" t="923" r="1858" b="924"/><rect l="651" t="924" r="1858" b="925"/><rect l="1056" t="925" r="1858" b="926"/><rect l="1460" t="926" r="1858" b="927"/></region>
+</block>
+<block blockType="Picture" l="175" t="973" r="1856" b="1783"><region><rect l="177" t="973" r="250" b="974"/><rect l="177" t="974" r="655" b="975"/><rect l="177" t="975" r="1059" b="976"/><rect l="177" t="976" r="1464" b="977"/><rect l="177" t="977" r="1855" b="978"/><rect l="177" t="978" r="1856" b="986"/><rect l="176" t="986" r="1856" b="989"/><rect l="176" t="989" r="1855" b="1390"/><rect l="175" t="1390" r="1855" b="1394"/><rect l="175" t="1394" r="1854" b="1779"/><rect l="247" t="1779" r="1854" b="1780"/><rect l="651" t="1780" r="1854" b="1781"/><rect l="1056" t="1781" r="1854" b="1782"/><rect l="1460" t="1782" r="1854" b="1783"/></region>
+</block>
+</page>
+</document>


### PR DESCRIPTION
Apperntly, FineReader can also output XML files with less information. Maybe it has to do with the lang="OldGerman" setting. Font family and font size have to be added during the conversion.
I have also added an example document and a unit test.